### PR TITLE
Potential fix for issue 0000602

### DIFF
--- a/wwwroot/inc/functions.php
+++ b/wwwroot/inc/functions.php
@@ -2266,7 +2266,7 @@ function ip4_range_size ($range)
 
 function ip4_mask_size ($mask)
 {
-	return (0xffffffff >> $mask) + 1;
+	return bcdiv(0xffffffff , bcpow(2, $mask)) + 1;
 }
 
 // returns array with keys 'ip', 'ip_bin', 'mask', 'mask_bin'


### PR DESCRIPTION
We were affected by this bug: http://bugs.racktables.org/view.php?id=602

Discovered it was due to being on a 32-bit system and the PHP_MAX_INT being half the size of 0xffffffff.

Test Code:

```
<?php

echo (0xffffffff >> 24);
echo "\n";
echo PHP_INT_MAX;
echo "\n";

?>
```

32-bit Output (capacity not being shown, bug present):

-1
2147483647

64-bit Output (capacity working, bug not present):

255
9223372036854775807

My first pull request so let me know if I've done anything wrong.
- Rhys
