### PR TITLE
Allow for custom css rules without breaking integrity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 wwwroot/inc/secret.php
 wwwroot/inc/local.php
+wwwroot/css/custom.css
 /.project
 tags
 plugins/*

--- a/wwwroot/inc/init.php
+++ b/wwwroot/inc/init.php
@@ -106,6 +106,7 @@ $pageheaders = array
 	100 => "<link rel='ICON' type='image/x-icon' href='?module=chrome&uri=pix/favicon.ico' />",
 );
 addCSS ('css/pi.css');
+addCSS ('css/custom.css');
 
 if (!isset ($script_mode) or $script_mode !== TRUE)
 {


### PR DESCRIPTION
This adds a second, untracked, custom.css as a placeholder for changes to the style of RackTables. I use custom css rules to adjust RackTables to our CI
