### PR TITLE
fix sshnokey functionality

### DIFF
--- a/wwwroot/inc/remote.php
+++ b/wwwroot/inc/remote.php
@@ -270,6 +270,7 @@ function makeGatewayParams ($object_id, $tolerate_remote_errors, /*array(&)*/$re
 			$params_from_settings['prompt-delay'] = 'prompt_delay';
 			$params_from_settings['username'] = 'username';
 			$params_from_settings['password'] = 'password';
+			$params_from_settings[] = $settings['hostname'];
 			break;
 		case 'ssh':
 			$params_from_settings['sudo-user'] = 'sudo_user';


### PR DESCRIPTION
For some reason; 'sshnokey', as committed earlier might not actually work. At least in 0.20.5 and HEAD when i commited this, Racktables complained about needing an hostname for the sshnokey gateway. Regardless of where this problem started, this patch should add a hostname to the sshnokey gateway so it can be used in 'live ports'
