### PR TITLE
Prevent infinite loops in rackspace view

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -405,7 +405,7 @@ function renderRackspace ()
 							makeHref(array('page'=>'location', 'location_id'=>$parentLocation['id'])) .
 							"${cellfilter['urlextra']}'>${parentLocation['name']}</a> " .
 							$locationTree;
-						$location_id = $parentLocation['parent_id'];
+						$location_id = ($parentLocation['parent_id'] == $location_id) ? 0 : $parentLocation['parent_id'];
 				}
 				$locationTree = substr ($locationTree, 8);
 				echo $locationTree;


### PR DESCRIPTION
Somehow a user was able to get a location to be its own parent which caused an infinite loop. This assumes a location has no parent if it detects it is its own parent.
