### PR TITLE
Updates to SNMP sync code for Bugs #767,#977,#983,#991

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,7 +15,7 @@
 	update: add F5 VIPRION models to dictionary (#987)
 	update: SNMP support for Cisco ME-3400EG-2CS-A (#939), WS-C2960CG-8TC-L (#933),
 		WS-CBS3012-IBM/-I (#871), WS-C3560-8PC (#975), WS-C2950-12 (#973),
-		WS-C2950G-24-DC (#981), WS-C3560GV2-48TS (#983),
+		WS-C2950G-24-DC (#981), WS-C3560GV2-48TS (#983), WS-C2950SX-24 (#991),
 		HP ProCurve J9028B (#941), J9022A (#767) by Mark Wilkinson
 	bugfix: update of Cisco WS-C4948 SNMPsync port definitions (#977) by Mark Wilkinson
 	new feature: port tracing (#333)

--- a/wwwroot/inc/dictionary.php
+++ b/wwwroot/inc/dictionary.php
@@ -482,7 +482,7 @@ $dictionary = array
 	382 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst 2950C-24'),
 	383 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst WS-C2950G-24-DC'),
 	384 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst 2950SX-48'),
-	385 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst 2950SX-24'),
+	385 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst WS-C2950SX-24'),
 	386 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst 2950T-24'),
 	387 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst 2950T-48'),
 	388 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Catalyst 2950G-12'),

--- a/wwwroot/inc/snmp.php
+++ b/wwwroot/inc/snmp.php
@@ -1712,6 +1712,12 @@ $known_switches = array // key is system OID w/o "enterprises" prefix
 		'text' => 'WS-C2950G-24-DC 24 RJ-45/10-100TX + 2 GBIC/1000',
 		'processors' => array ('catalyst-chassis-any-1000GBIC','catalyst-chassis-any-100TX'),
 	),
+	'9.1.480' => array
+	(
+		'dict_key' => 385,
+		'text' => 'WS-C2950SX-24 24 RJ-45/10-100TX + 2 1000Base-SX',
+		'processors' => array ('catalyst-chassis-uplinks-1000SX','catalyst-chassis-any-100TX'),
+	),
 	'9.1.527' => array
 	(
 		'dict_key' => 210,


### PR DESCRIPTION
3 new devices,
1 Tweak to port definitions
1 table_processor entry name change : catalyst-9-to-12-1000SFP to catalyst-9-to-12-combo-1000SFP
   this brings it into line with other table_processor entries.
