### PR TITLE
Update config.php

### DIFF
--- a/wwwroot/inc/config.php
+++ b/wwwroot/inc/config.php
@@ -13,6 +13,6 @@ committers' copies) can run into issues:
    have already been executed.
 */
 
-define ('CODE_VERSION', '0.20.6');
+define ('CODE_VERSION', '0.20.7');
 
 ?>


### PR DESCRIPTION
Release 0.20.7 announce in readme doesn't match config.php version code in release head branch.

Consequence, install.php doesn't detect to upgrade database and the code : 
alter database character set utf8 collate utf8_unicode_ci  is not executed on 0.20.6 database. 
