### PR TITLE
Fix UI reset after MGMT_PROTOS change in 0.20.6

### DIFF
--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -1414,9 +1414,7 @@ function resetUIConfig()
 	setConfigVar ('SYNCDOMAIN_MAX_PROCESSES', '0');
 	setConfigVar ('PORT_EXCLUSION_LISTSRC', '{$typeid_3} or {$typeid_10} or {$typeid_11} or {$typeid_1505} or {$typeid_1506}');
 	setConfigVar ('FILTER_RACKLIST_BY_TAGS', 'yes');
-	setConfigVar ('SSH_OBJS_LISTSRC', 'false');
-	setConfigVar ('RDP_OBJS_LISTSRC', 'false');
-	setConfigVar ('TELNET_OBJS_LISTSRC', 'false');
+	setConfigVar ('MGMT_PROTOS', 'ssh: {$typeid_4}; telnet: {$typeid_8}');
 	setConfigVar ('SYNC_802Q_LISTSRC', '');
 	setConfigVar ('QUICK_LINK_PAGES', 'depot,ipv4space,rackspace');
 	setConfigVar ('CACTI_LISTSRC', 'false');


### PR DESCRIPTION
In 0.20.6 TELNET_OBJS_LISTSRC, SSH_OBJS_LISTSRC, and RDP_OBJS_LISTSRC
were replaced with a single MGMT_PROTOS option, but the UI reset code
was not updated and so still attempted to reset the objects which no
longer existed...
