### PR TITLE
Update auth.php with LDAP option to specify port

### DIFF
--- a/wwwroot/inc/auth.php
+++ b/wwwroot/inc/auth.php
@@ -470,7 +470,7 @@ function queryLDAPServer ($username, $password)
 	if(extension_loaded('ldap') === FALSE)
 		throw new RackTablesError ('LDAP misconfiguration. LDAP PHP Module is not installed.', RackTablesError::MISCONFIGURED);
 
-	$connect = @ldap_connect ($LDAP_options['server']);
+	$connect = @ldap_connect ($LDAP_options['server'], $LDAP_options['port']);
 	if ($connect === FALSE)
 		return array ('result' => 'CAN');
 


### PR DESCRIPTION
We use Zentyal which used different port for LDAP read only queries, by default on port 390.

Below example configrarion, hope someone will find it helpful someday. Remember to adjust to your needs.
I have not tested TLS, yet.

Example configuration fto include in secure.php:

$LDAP_options = array
(
    'server' => 'zentyal-dc.example.com',
    'port' => 390,
    'domain' => '',
    'search_attr' => 'uid',
    'search_dn' => 'dc=dir,dc=example,dc=com',
 // The following credentials will be used when searching for the user's DN:
    'search_bind_rdn' => 'cn=zentyalro,dc=dir,dc=example,dc=com',
    'search_bind_password' => 'enter_pass_here',
    'displayname_attrs' => 'cn',
    'options' => array (LDAP_OPT_PROTOCOL_VERSION => 3),
    'use_tls' => 0,         // 0 == don't attempt, 1 == attempt, 2 == require
);
