### PR TITLE
Proper way to redefine constants

### DIFF
--- a/wwwroot/inc/functions.php
+++ b/wwwroot/inc/functions.php
@@ -10,10 +10,8 @@
 *
 */
 
-// PHP messages in the following defines are suppressed because of the possibility
-// that they are already defined by user in secret.php file
-@define ('TAGNAME_REGEXP', '/^[\p{L}0-9-]( ?([._~+%-] ?)?[\p{L}0-9:])*(%|\+)?$/u');
-@define ('AUTOTAGNAME_REGEXP', '/^\$[\p{L}0-9-]( ?([._~+%-] ?)?[\p{L}0-9:])*(%|\+)?$/u');
+defineIfNotDefined ('TAGNAME_REGEXP', '/^[\p{L}0-9-]( ?([._~+%-] ?)?[\p{L}0-9:])*(%|\+)?$/u');
+defineIfNotDefined ('AUTOTAGNAME_REGEXP', '/^\$[\p{L}0-9-]( ?([._~+%-] ?)?[\p{L}0-9:])*(%|\+)?$/u');
 
 $loclist[0] = 'front';
 $loclist[1] = 'interior';


### PR DESCRIPTION
Suppressing errors by using control operators (@) is not very good idea. Errors will be suppressed, but will still be caught by track_errors feature and custom error handler functions.
