### PR TITLE
reduce number of calls tagOnChain()

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -2173,13 +2173,16 @@ function renderRackSpaceForObject ($object_id)
 		$object = spotEntity ('object', $object_id);
 		$matched_tags = array();
 		foreach ($allRacksData as $rack)
+		{
+			$tag_chain = array_replace ($rack['etags'], $rack['itags']);
 			foreach ($object['etags'] as $tag)
-				if (tagOnChain ($tag, $rack['etags']) or tagOnChain ($tag, $rack['itags']))
+				if (tagOnChain ($tag, $tag_chain))
 				{
 					$matching_racks[$rack['id']] = $rack;
 					$matched_tags[$tag['id']] = $tag;
 					break;
 				}
+		}
 		// add current object's racks even if they dont match filter
 		foreach ($workingRacksData as $rack_id => $rack)
 			if (! isset ($matching_racks[$rack_id]))


### PR DESCRIPTION
Before this patch, tagOnChain is called rack_count \* object_etags_count \* 2(in
most cases). In my testing was 3000 racks and 5 etags on object. I ran
10 rounds of renderRackSpaceForObject() and get 7.03 sec before, and
6.32 after patching.
