### PR TITLE
makeHref() use http_build_query()

### DIFF
--- a/wwwroot/inc/functions.php
+++ b/wwwroot/inc/functions.php
@@ -2741,20 +2741,7 @@ function mkA ($text, $nextpage, $bypass = NULL, $nexttab = NULL)
 // make "HREF" HTML attribute
 function makeHref ($params = array())
 {
-	$tmp = array();
-	foreach ($params as $key => $value)
-	{
-		if (is_array ($value))
-			$key .= "[]";
-		else
-			$value = array ($value);
-		if (!count ($value))
-			$tmp[] = urlencode ($key) . '=';
-		else
-			foreach ($value as $sub_value)
-				$tmp[] = urlencode ($key) . '=' . urlencode ($sub_value);
-	}
-	return 'index.php?' . implode ('&', $tmp);
+	return 'index.php?' . http_build_query ($params);
 }
 
 function makeHrefProcess ($params = array())


### PR DESCRIPTION
Use built-in function instead homegrown function. In my tests i get 1,7 seconds to render index.php?page=ipv4slb&tab=rservers with 20k server(40k makeHref() calls), and 1.3 after this patch.
