### PR TITLE
Fix interface status for Extreme Networks xos12/15

### DIFF
--- a/wwwroot/inc/deviceconfig.php
+++ b/wwwroot/inc/deviceconfig.php
@@ -104,14 +104,14 @@ function xos12ReadInterfaceStatus ($input)
 {
 	$ret = array();
 	foreach (explode ("\n", $input) as $line)
-		if (preg_match('/^(\d+)\s+([ED])[a-zA-Z-]+\s+(active|ready)\s+/', $line, $m))
+		if (preg_match('/^(\d+|\d:\d+)\s+.*\s+([ED])\s+([AR])\s+/', $line, $m))
 		{
-			$portname = shortenIfName ($m[1]);
-			if ($m[3] == 'active')
+			$portname = $m[1];
+                        if ($m[2] == 'E' and $m[3] == 'A')
 				$status = 'up';
-			elseif ($m[2] == 'E')
+			elseif ($m[2] == 'E' and $m[3] == 'R' )
 				$status = 'down';
-			else
+			elseif ($m[2] == 'D')
 				$status = 'disabled';
 			$ret[$portname]['status'] = $status;
 		}
@@ -1695,7 +1695,7 @@ function xos12TranslatePushQueue ($dummy_object_id, $queue, $dummy_vlan_names)
 			$ret .= "show configuration\n";
 			break;
 		case 'getportstatus':
-			$ret .= "show ports information\n";
+			$ret .= "show ports no-refresh\n";
 			break;
 		case 'getmaclist':
 			$ret .= "show fdb\n";

--- a/wwwroot/inc/deviceconfig.php
+++ b/wwwroot/inc/deviceconfig.php
@@ -114,6 +114,7 @@ function xos12ReadInterfaceStatus ($input)
 			elseif ($m[2] == 'D')
 				$status = 'disabled';
 			$ret[$portname]['status'] = $status;
+			unset ($status);
 		}
 	return $ret;
 }


### PR DESCRIPTION
Currently RT uses "show ports information" to get port status from
device. Example of output ![show_ports_information](https://cloud.githubusercontent.com/assets/4509531/6197003/eb10b0e2-b3ef-11e4-9acc-c0d022169541.png).
There are two problems with this output:
1) Interface name is from IfDescription and is truncated, so exact match is not
possible.
2) With extreme switches "Local name" field should be in format of either
\[port-number\] (1-24 for 24 port switch) or in case of stack of switches
\[number-in-stack\]:\[port-number\] (1:1-24, 2:1-24, etc...) otherwise Live LLDP
will fail to identify ports.
Considering above i have decided to change command to "show ports no-refresh"
which gives output as below,
![show_ports_no-refresh](https://cloud.githubusercontent.com/assets/4509531/6197002/eb0cf5d8-b3ef-11e4-8e8c-dd8a327132ac.png)
and made changes accordingly.