### PR TITLE
DB Mutex improvements

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -5908,12 +5908,13 @@ function getDBName()
 // A lock is implicitly released on any subsequent call to setDBMutex in the same connection
 function setDBMutex ($name, $timeout = 5)
 {
-	$result = usePreparedSelectBlade ('SELECT GET_LOCK(?, ?)', array (getDBName() . '.' . $name, $timeout));
+	$fullname = getDBName() . '.' . $name;
+	$result = usePreparedSelectBlade ('SELECT GET_LOCK(?, ?)', array ($fullname, $timeout));
 	$row = $result->fetch (PDO::FETCH_COLUMN, 0);
 	if ($row === NULL)
-		throw new RTDatabaseError ("error occured when executing GET_LOCK");
+		throw new RTDatabaseError ("error occured when executing GET_LOCK on $fullname");
 	if ($row !== '1')
-		throw new RTDatabaseError ('lock wait timeout');
+		throw new RTDatabaseError ("lock wait timeout for $fullname");
 }
 
 function tryDBMutex ($name, $timeout = 0)
@@ -5933,8 +5934,6 @@ function releaseDBMutex ($name)
 {
 	$result = usePreparedSelectBlade ('SELECT RELEASE_LOCK(?)', array (getDBName() . '.' . $name));
 	$row = $result->fetch (PDO::FETCH_COLUMN, 0);
-	if ($row === NULL)
-		throw new RTDatabaseError ("error occured when executing RELEASE_LOCK");
 	return $row === '1';
 }
 


### PR DESCRIPTION
Add Mutex name in setDBMutex exceptions
releaseDBMutex will not throw exception anymore