### PR TITLE
Prevent tests from running on non-unittest db.

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,14 +1,61 @@
 This directory stores PHPUnit tests.
 
-#############################
-#          WARNING          #
-#############################
-Do not run these tests against a production instance of RackTables!
-Data may be added, modified or deleted as part of the tests.
-If you understand the risk, edit bootstrap.php and delete the warning lines.
-
 To run a specific test:
 $ phpunit TestName
 
 To run all tests:
 $ phpunit
+
+
+The Unit Testing Database
+-------------------------
+
+Tests should never be run against a production instance of Racktables.
+Data may be added, modified or deleted as part of the tests.  Even if
+tests clean up after themselves, it's possible for data to get left
+behind.
+
+The bootstrap.php script (configured for use in phpunit.xml) calls
+method TestHelper::ensureUsingUnitTestDatabase() to check that the
+database DSN contains the string "_unittest".
+
+Checking the DSN is a relatively easy way to ensure that tests are
+only run with a dedicated testing database.  While PHPUnit supports
+Database_TestCases (ref
+https://phpunit.de/manual/current/en/database.html), the Racktables
+tests do not yet use that framework.  This may be incorporated at a
+future date.
+
+
+Creating and configuring a Unit Testing Database
+------------------------------------------------
+
+Assuming you have installed your development Racktables using the web
+interface, you will already have a working database.  You can clone
+that database to a new dedicated unit testing database (where the
+database name contains the string "_unittest") from the command line
+as follows:
+
+  mysql -uroot -p
+  create database racktables_unittest;   # db dedicated to testing
+  grant all on racktables_unittest.* to root;
+  grant all on racktables_unittest.* to root@localhost;
+
+  # Note for the below, you should use the $db_username
+  # contained in wwwroot/inc/secret.php instead of <rackuser>.
+  grant all on racktables_unittest.* to <rackuser>;
+  grant all on racktables_unittest.* to <rackuser>@localhost;
+  exit
+
+Then duplicate the existing database to your new unit testing database:
+
+  mysqldump -h localhost -u <rackuser> -p<rackpw> <original_db_name> |
+  mysql -h localhost -u <rackuser> -p<rackpw> racktables_unittest
+
+
+Edit the secret file and change the dbname in $pdo_dsn to the new
+"_unittest" database, eg:
+
+  $pdo_dsn = 'mysql:host=127.0.01;dbname=racktables_unittest';
+
+To switch to another database, edit the secret file.

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -1,0 +1,19 @@
+<?php
+
+// Miscellaneous test helpers.
+class TestHelper
+{
+
+	// Throws if the dsn name doesn't contain the string "_unittest".
+	//
+	// Assuming here that a production database would never contain
+	// that string.  See tests/README for more details.
+	public static function ensureUsingUnitTestDatabase()
+	{
+		global $pdo_dsn;
+		if (stristr($pdo_dsn, '_unittest') === FALSE) {
+			throw new Exception("Test must connect to unit testing database (see tests/README).");
+		}
+	}
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,12 @@
 <?php
-WARNING: Do not run these tests against a production instance of RackTables!
-WARNING: Data may be added, modified or deleted as part of the tests.
-WARNING: If you understand the risk, delete these warning lines.
 global $pdo_dsn, $db_username, $db_password;
 global $remote_username, $SQLSchema, $configCache, $script_mode;
+
 $script_mode = TRUE;
 require_once '../wwwroot/inc/init.php';
 require_once '../wwwroot/inc/interface.php';
+require_once './TestHelper.php';
+
+# Sanity check of connection.
+TestHelper::ensureUsingUnitTestDatabase();
 ?>


### PR DESCRIPTION
This change ensures that developers who run the unit tests don't accidentally run the tests against a production database.

If the $pdo_dsn (in secret.php) doesn't contain the string "_unittest", this PR causes phpunit to fail with `PHP Fatal error:  Uncaught exception 'Exception' with message 'Test must connect to unit testing database (see tests/README).'`.

e.g.,
- `$pdo_dsn = 'mysql:host=127.0.01;dbname=racktables';` = tests fail with above error
- `$pdo_dsn = 'mysql:host=127.0.01;dbname=racktables_unittest';` = tests are executed