### PR TITLE
fix new install CREATE TABLE VLANDomain

### DIFF
--- a/wwwroot/inc/install.php
+++ b/wwwroot/inc/install.php
@@ -1129,7 +1129,7 @@ function get_pseudo_file ($name)
   `description` char(255) default NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `description` (`description`),
-  CONSTRAINT `VLANDomain-FK-group_id` FOREIGN KEY (`group_id`) REFERENCES `VLANDomain` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `VLANDomain-FK-group_id` FOREIGN KEY (`group_id`) REFERENCES `VLANDomain` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB";
 
 		$query[] = "CREATE TABLE `VLANIPv4` (


### PR DESCRIPTION
The following queries failed:
CREATE TABLE `VLANDomain` (
  `id` int(10) unsigned NOT NULL auto_increment,
  `group_id` int(10) unsigned default NULL,
  `description` char(255) default NULL,
  PRIMARY KEY  (`id`),
  UNIQUE KEY `description` (`description`),
  CONSTRAINT `VLANDomain-FK-group_id` FOREIGN KEY (`group_id`) REFERENCES `VLANDomain` (`id`) ON DELETE SET NULL,
) ENGINE=InnoDB -- You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') ENG