### PR TITLE
Added 'comment' field to getObjectAttrsSearchResults

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -3175,7 +3175,7 @@ function getObjectSearchResults ($what)
 function getObjectAttrsSearchResults ($what)
 {
 	$ret = array();
-	foreach (array ('name', 'label', 'asset_no') as $column)
+	foreach (array ('name', 'label', 'asset_no', 'comment') as $column)
 	{
 		$tmp = getSearchResultByField
 		(


### PR DESCRIPTION
This allows for searching the "comments" field of objects (VMs etc).  This doesn't return the comment field as part of the search results; I think this is actually OK, as comment fields can be *huge.*

RackTables search allows searching by comment in many types of resources, but not VMs, other objects. This brings objects in line with the rest.  Also submitted as a patch at https://bugs.racktables.org/view.php?id=1489