### PR TITLE
allow additional object reset

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -1407,6 +1407,8 @@ function commitResetObject ($object_id = 0)
 	usePreparedDeleteBlade ('CactiGraph', array ('object_id' => $object_id));
 	# Munin graphs
 	usePreparedDeleteBlade ('MuninGraph', array ('object_id' => $object_id));
+	# Do an additional reset if needed
+	callHook ('resetObject_hook', $object_id);
 }
 
 function commitUpdateRack ($rack_id, $new_row_id, $new_name, $new_height, $new_has_problems, $new_asset_no, $new_comment)


### PR DESCRIPTION
add hook 'resetObject_hook' that runs on commitResetObject for
additional object reset (ex. in plugins)