### PR TITLE
Adds $has_problem_(yes|no) automatic tag

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -4173,6 +4173,7 @@ function generateEntityAutoTags ($cell)
 		case 'object':
 			$ret[] = array ('tag' => '$id_' . $cell['id']);
 			$ret[] = array ('tag' => '$typeid_' . $cell['objtype_id']);
+			$ret[] = array ('tag' => '$has_problems_' . $cell['has_problems']);
 			$ret[] = array ('tag' => '$any_object');
 			if ($cell['name'] == '')
 				$ret[] = array ('tag' => '$nameless');


### PR DESCRIPTION
This change adds an automatic tag for objects based on the bolean value of the
has_problem attribute :
Objects with problems can be filtered using the $has_problems_yes tag.
Of course the $has_problem_no tag provides the opposite filtering.