### PR TITLE
Allow the ucs gateway to import rackmount servers

### DIFF
--- a/gateways/ucssdk
+++ b/gateways/ucssdk
@@ -23,11 +23,12 @@ import sys
 try:
 	from UcsSdk import *
 	from UcsSdk.MoMeta.NetworkElement import NetworkElement
-        from UcsSdk.MoMeta.EquipmentChassis import EquipmentChassis
-        from UcsSdk.MoMeta.ComputeBlade import ComputeBlade
+	from UcsSdk.MoMeta.EquipmentChassis import EquipmentChassis
+	from UcsSdk.MoMeta.ComputeBlade import ComputeBlade
+	from UcsSdk.MoMeta.ComputeRackUnit import ComputeRackUnit
 	handle = UcsHandle()
 except Exception, err:
-	sys.stderr.write('UCS Python SDK is missing\n')
+	sys.stderr.write('UCS Python SDK is missing %s (Path: %s)\n' % (str(err), sys.path))
 	sys.exit(2)
 
 loggedin = 0
@@ -79,6 +80,9 @@ while 1:
 				print "COLUMNS type,serial,DN,model,assigned,slot"
 				for bl in handle.GetManagedObject(None, ComputeBlade.ClassId()):
 					print "ROW ComputeBlade,"     + bl.Serial + "," + bl.Dn + "," + bl.Model + "," + bl.AssignedToDn + "," + bl.SlotId
+				print "COLUMNS type,serial,DN,model,assigned"
+				for rm in handle.GetManagedObject(None, ComputeRackUnit.ClassId()):
+					print "ROW ComputeRackUnit,"     + rm.Serial + "," + rm.Dn + "," + rm.Model + "," + rm.AssignedToDn
 				print "OK enumeration complete"
 			except Exception, err:
 				print "ERR exception occured, logging out"

--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -3308,6 +3308,7 @@ $ucsproductmap = array
 	'UCSB-B260-M4' => 2223,   # B260 M4
 	'UCSB-B460-M4' => 2224,   # B460 M4
 	'UCSB-B200-M4' => 2225,   # B200 M4
+	'UCSC-C240-M3S' => 1754,  # C240 M3 Rackmount Server
 );
 
 function autoPopulateUCS()
@@ -3375,6 +3376,24 @@ function autoPopulateUCS()
 			$parent_name = preg_replace ('#^([^/]+)/([^/]+)/([^/]+)$#', '${1}/${2}', $item['DN']);
 			if (array_key_exists ($parent_name, $chassis_id))
 				commitLinkEntities ('object', $chassis_id[$parent_name], 'object', $new_object_id);
+			$done++;
+		}
+		elseif ($item['type'] == 'ComputeRackUnit')
+		{
+			if ($item['assigned'] == '')
+				$new_object_id = commitAddObject ($mname, NULL, 4, NULL);
+			else
+			{
+				$spname = preg_replace ('#.+/ls-(.+)#i', '${1}', $item['assigned']) . "(" . $oinfo['name'] . ")";
+				$new_object_id = commitAddObject ($spname, NULL, 4, NULL);
+			}
+			# Set H/W Type for RackmountServer
+			if (array_key_exists ($item['model'], $ucsproductmap))
+				commitUpdateAttrValue ($new_object_id, 2, $ucsproductmap[$item['model']]);
+			# Set Serial#
+			commitUpdateAttrValue ($new_object_id, 1, $item['serial']);
+			$parent_name = preg_replace ('#^([^/]+)/([^/]+)/([^/]+)$#', '${1}/${2}', $item['DN']);
+			commitLinkEntities ('object', $ucsm_id, 'object', $new_object_id);
 			$done++;
 		}
 	} # endfor


### PR DESCRIPTION
Newer versions of the Cisco UCS system can manage rackmount servers that
are linked with a Cisco VIC network card to the Fabric Interconnects.
By adding a new element (ComputeRackUnit) to `gateways/ucssdk` it is able
to detect these rackmount servers by Cisco (C-Series).

In `ophandlers.php` the function `autoPopulateUCS()` is extended to create
the according server object.

If a "Object container compatibility" for Parent "Management interface" to Child "Server"
is added in the RackTables configuration, the list for the Mangament Interface will contain the linked servers as well, not only network switches and server chassis.