### PR TITLE
Add IPV4_TREE_SHOW_UNALLOCATED config option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,8 @@
 	update: new 100G port types support (empty CXP, CR4, CR10, LR10, ER10)
 	update: warn when already used or reserved IP is assigned to object
 	update: allow to redefine the expiration report parameters in local plugins
+	update: allow to hide unallocated networks from IPv4 tree via
+		IPV4_TREE_SHOW_UNALLOCATED user configuration option
 0.20.10 2015-01-26
 	bugfix: port type could not be changed for an unlinked modular port (#1393)
 	bugfix: crash on object's rackspace page when PHP < 5.3 (array_replace is missing)

--- a/wwwroot/inc/install.php
+++ b/wwwroot/inc/install.php
@@ -2198,6 +2198,7 @@ WHERE O.objtype_id = 1562";
 		$query[] = "INSERT INTO PortCompat SELECT pc1.type2, pc1.type1 FROM PortCompat pc1 LEFT JOIN PortCompat pc2 ON pc1.type1 = pc2.type2 AND pc1.type2 = pc2.type1 WHERE pc2.type1 IS NULL";
 
 		$query[] = "INSERT INTO `Config` (varname, varvalue, vartype, emptyok, is_hidden, is_userdefined, description) VALUES
+('IPV4_TREE_SHOW_UNALLOCATED', 'yes', 'string', 'no', 'no', 'yes', 'Show unallocated networks in IPv4 tree'),
 ('MASSCOUNT','8','uint','no','no','yes','&quot;Fast&quot; form is this many records tall'),
 ('MAXSELSIZE','30','uint','no','no','yes','&lt;SELECT&gt; lists height'),
 ('enterprise','MyCompanyName','string','no','no','no','Organization name'),

--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -2570,7 +2570,7 @@ function renderIPSpaceRecords ($tree, $baseurl, $target = 0, $level = 1)
 			if ($item['symbol'] == 'node-expanded' or $item['symbol'] == 'node-expanded-static')
 				$self ($item['kids'], $baseurl, $target, $level + 1);
 		}
-		else
+		elseif (getConfigVar ('IPV4_TREE_SHOW_UNALLOCATED') == 'yes')
 		{
 			// non-allocated (spare) IP range
 			echo "<tr valign=top>";

--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -1640,6 +1640,7 @@ function resetUIConfig()
 		'REVERSED_RACKS_LISTSRC' => 'false',
 		'NEAREST_RACKS_CHECKBOX' => 'yes',
 		'SHOW_OBJECTTYPE' => 'yes',
+		'IPV4_TREE_SHOW_UNALLOCATED' => 'yes',
 	);
 	foreach ($defaults as $name => $value)
 		setConfigVar ($name, $value);

--- a/wwwroot/inc/upgrade.php
+++ b/wwwroot/inc/upgrade.php
@@ -219,6 +219,12 @@ installation. If desired so, you could eliminate the case-duplicating rows
 and re-apply the failed query.
 ENDOFTEXT
 ,
+        '0.20.11' => <<<ENDOFTEXT
+New IPV4_TREE_SHOW_UNALLOCATED configuration option introduced to disable
+dsplaying unallocated networks in IPv4 space tree. Setting it also disables
+KNIGHT feature.
+ENDOFTEXT
+,
 );
 
 // At the moment we assume, that for any two releases we can
@@ -1932,7 +1938,9 @@ VALUES ('SHOW_OBJECTTYPE',  'no',  'string',  'no',  'no',  'yes',  'Show object
 			// ABI_ver = 2, invalidate RackCode cache
 			$query[] = "DELETE FROM Script WHERE script_name='RackCodeCache'";
 
+			$query[] = "INSERT INTO Config (varname, varvalue, is_hidden, is_userdefined, description) VALUES ('IPV4_TREE_SHOW_UNALLOCATED', 'yes', 'no', 'yes', 'Show unallocated networks in IPv4 tree'); ";
 			$query[] = "UPDATE Config SET varvalue = '0.20.11' WHERE varname = 'DB_VERSION'";
+
 			break;
 		case 'dictionary':
 			$query = reloadDictionary();


### PR DESCRIPTION
IPV4_TREE_SHOW_UNALLOCATED user configurable option allows to hide unallocated networks from IPv4 network list.