### PR TITLE
Fix unicode problem in printObjectDetailsForRenderRack

### DIFF
--- a/wwwroot/inc/exceptions.php
+++ b/wwwroot/inc/exceptions.php
@@ -293,7 +293,7 @@ class RackCodeError extends RackTablesError
 class RTImageError extends RackTablesError
 {
 	protected $imgbin;
-	function __construct ($subject)
+	function __construct ($subject = NULL)
 	{
 		$map = array
 		(


### PR DESCRIPTION
Unicode symbols(russian for example) in blade names displayed incorrectly