### PR TITLE
common name for blade server(utf-8) was shown incorrectly in racks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 0.20.12
+	bugfix: common name for blade server(utf-8) was shown incorrectly in racks (by Artem Yankovskiy)
 	update: Huawei telnet gateway uses the 'terminal echo-mode line' command
 0.20.11 2016-02-07
 	bugfix: Tag Picker does not display the full tag list as a tree (#1403)

--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -899,9 +899,11 @@ function printObjectDetailsForRenderRack ($object_id, $hl_obj_id = 0)
 								echo " class='${slotClass[$s]}'>${slotTitle[$s]}";
 								if ($layout == 'V')
 								{
-									$tmp = substr ($slotInfo[$s], 0, 1);
-									foreach (str_split (substr ($slotInfo[$s], 1)) as $letter)
-										$tmp .= '<br>' . $letter;
+									$tmp = mb_substr($slotInfo[$s], 0, 1);
+									for($i = 1; $i < mb_strlen($slotInfo[$s]); $i++)
+									{
+										$tmp .= '<br>' . mb_substr($slotInfo[$s], $i, 1);
+									}
 									$slotInfo[$s] = $tmp;
 								}
 								echo mkA ($slotInfo[$s], 'object', $slotData[$s]);


### PR DESCRIPTION
If blade server contains utf-8 symbols in common name we have display problem in rackspace.