### PR TITLE
Use Cmd+Click to inverse tag selection on OS X

### DIFF
--- a/wwwroot/js/tag-cb.js
+++ b/wwwroot/js/tag-cb.js
@@ -44,7 +44,7 @@ function cbClick (event, bInvert) {
 	var checked = cb.attr('checked');
 	if (bInvert)
 		checked = ! checked;
-	if (event.ctrlKey && ! td.hasClass('inverted') && checked) {
+	if ((event.ctrlKey || event.metaKey) && ! td.hasClass('inverted') && checked) {
 		var name = cb.attr('name');
 		if (name.match(/^cf([tp]\[\])$/))
 			cb.attr('name', 'nf' + RegExp.$1);


### PR DESCRIPTION
On Windows you may use Ctrl+Click to select a tag with inversion, but on OS X that click will open a context menu. So we should handle Cmd+Click as alternative.