### PR TITLE
Added code to disable AUTOPORTS for UCS objects

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -9224,6 +9224,8 @@ function renderEditUCSForm()
 	echo "<td class=tdleft colspan=2><input type=password name=ucs_password id=ucs_password></td></tr>\n";
 	echo "<tr><th colspan=3><input type=checkbox name=use_terminal_settings id=use_terminal_settings>";
 	echo "<label for=use_terminal_settings>Use Credentials from terminal_settings()</label></th></tr>\n";
+	echo "<tr><th colspan=3><input type=checkbox name=disable_autoports checked id=disable_autoports>";
+	echo "<label for=disable_autoports>Disable creating default AUTOPORTS(i.e. kvm, eth0, eth1)</label></th></tr>\n";
 	echo "<tr><th class=tdright>Actions:</th><td class=tdleft>";
 	printImageHREF ('DQUEUE sync_ready', 'Auto-populate UCS', TRUE);
 	echo '</td><td class=tdright>';

--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -3317,6 +3317,12 @@ function autoPopulateUCS()
 	$oinfo = spotEntity ('object', $ucsm_id);
 	$chassis_id = array();
 	$done = 0;
+	# Temporarily disable any "AUTOPORTS_CONFIG" setting as we will be using the config from each blade
+	if (isCheckSet ('disable_autoports'))
+	{
+		$autoportsTemp = getConfigVar ('AUTOPORTS_CONFIG');
+		setConfigVar ('AUTOPORTS_CONFIG', '');
+	}
 	# There are three request parameters (use_terminal_settings, ucs_login and
 	# ucs_password) not processed here. These are asserted and used inside
 	# queryTerminal().
@@ -3378,6 +3384,9 @@ function autoPopulateUCS()
 			$done++;
 		}
 	} # endfor
+	# Restore AUTOPORTS_CONFIG configuration setting
+	if (isCheckSet ('disable_autoports'))
+		setConfigVar ('AUTOPORTS_CONFIG', $autoportsTemp);
 	showSuccess ("Auto-populated UCS Domain '${oinfo['name']}' with ${done} items");
 }
 

--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -3317,12 +3317,6 @@ function autoPopulateUCS()
 	$oinfo = spotEntity ('object', $ucsm_id);
 	$chassis_id = array();
 	$done = 0;
-	# Temporarily disable any "AUTOPORTS_CONFIG" setting as we will be using the config from each blade
-	if (isCheckSet ('disable_autoports'))
-	{
-		$autoportsTemp = getConfigVar ('AUTOPORTS_CONFIG');
-		setConfigVar ('AUTOPORTS_CONFIG', '');
-	}
 	# There are three request parameters (use_terminal_settings, ucs_login and
 	# ucs_password) not processed here. These are asserted and used inside
 	# queryTerminal().
@@ -3335,6 +3329,12 @@ function autoPopulateUCS()
 	{
 		showError ($e->getMessage());
 		return;
+	}
+	# Temporarily disable any "AUTOPORTS_CONFIG" setting as we will be using the config from each blade
+	if (isCheckSet ('disable_autoports'))
+	{
+		$autoportsTemp = getConfigVar ('AUTOPORTS_CONFIG');
+		setConfigVar ('AUTOPORTS_CONFIG', '');
 	}
 	foreach ($contents as $item)
 	{


### PR DESCRIPTION
Added checkbox to interface.php:renderEditUCSForm() to disable AUTOPORTS (kvm, eth0, eth1) during UCS object auto-creation
Added code to ophandlers.php:autoPopulateUCS() to temporarily disable AUTOPORTS_CONFIG and then restore it after creating UCS objects