### PR TITLE
Enhanced commitAddObject to allow disabling AUTOPORTS creation

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -927,7 +927,7 @@ function checkObjectNameUniqueness ($name, $type_id, $object_id = 0)
 		throw new InvalidRequestArgException ('name', $name, 'An object with that name already exists');
 }
 
-function commitAddObject ($new_name, $new_label, $new_type_id, $new_asset_no, $taglist = array())
+function commitAddObject ($new_name, $new_label, $new_type_id, $new_asset_no, $taglist = array(), $disable_autoports = FALSE)
 {
 	checkObjectNameUniqueness ($new_name, $new_type_id);
 	usePreparedInsertBlade
@@ -959,7 +959,7 @@ function commitAddObject ($new_name, $new_label, $new_type_id, $new_asset_no, $t
 	lastCreated ($realm, $object_id);
 
 	// Do AutoPorts magic
-	if ($realm == 'object')
+	if (($realm == 'object') && !$disable_autoports)
 		executeAutoPorts ($object_id);
 	// Now tags...
 	produceTagsForNewRecord ($realm, $taglist, $object_id);

--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -6346,6 +6346,8 @@ function renderEditUCSForm()
 	echo "<td class=tdleft colspan=2><input type=password name=ucs_password id=ucs_password></td></tr>\n";
 	echo "<tr><th colspan=3><input type=checkbox name=use_terminal_settings id=use_terminal_settings>";
 	echo "<label for=use_terminal_settings>Use Credentials from terminal_settings()</label></th></tr>\n";
+	echo "<tr><th colspan=3><input type=checkbox name=disable_autoports checked id=disable_autoports>";
+	echo "<label for=disable_autoports>Disable creating default AUTOPORTS(i.e. kvm, eth0, eth1)</label></th></tr>\n";
 	echo "<tr><th class=tdright>Actions:</th><td class=tdleft>";
 	printImageHREF ('DQUEUE sync_ready', 'Auto-populate UCS', TRUE);
 	echo '</td><td class=tdright>';

--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -3320,6 +3320,7 @@ function autoPopulateUCS()
 	$oinfo = spotEntity ('object', $ucsm_id);
 	$chassis_id = array();
 	$done = 0;
+	$disable_autoports = isCheckSet('disable_autoports');
 	# There are three request parameters (use_terminal_settings, ucs_login and
 	# ucs_password) not processed here. These are asserted and used inside
 	# queryTerminal().
@@ -3338,7 +3339,7 @@ function autoPopulateUCS()
 		$mname = preg_replace ('#^sys/(.+)$#', $oinfo['name'] . '/\\1', $item['DN']);
 		if ($item['type'] == 'NetworkElement')
 		{
-			$new_object_id = commitAddObject ($mname, NULL, 8, NULL);
+			$new_object_id = commitAddObject ($mname, NULL, 8, NULL, NULL, $disable_autoports);
 			#    Set H/W Type for Network Switch
 			if (array_key_exists ($item['model'], $ucsproductmap))
 				commitUpdateAttrValue ($new_object_id, 2, $ucsproductmap[$item['model']]);
@@ -3350,7 +3351,7 @@ function autoPopulateUCS()
 		}
 		elseif ($item['type'] == 'EquipmentChassis')
 		{
-			$chassis_id[$item['DN']] = $new_object_id = commitAddObject ($mname, NULL, 1502, NULL);
+			$chassis_id[$item['DN']] = $new_object_id = commitAddObject ($mname, NULL, 1502, NULL, NULL, $disable_autoports);
 			#    Set H/W Type for Server Chassis
 			if (array_key_exists ($item['model'], $ucsproductmap))
 				commitUpdateAttrValue ($new_object_id, 2, $ucsproductmap[$item['model']]);
@@ -3362,7 +3363,7 @@ function autoPopulateUCS()
 		elseif ($item['type'] == 'ComputeBlade')
 		{
 			if ($item['assigned'] == '')
-				$new_object_id = commitAddObject ($mname, NULL, 4, NULL);
+				$new_object_id = commitAddObject ($mname, NULL, 4, NULL, NULL, $disable_autoports);
 			else
 			{
 				$spname = preg_replace ('#.+/ls-(.+)#i', '${1}', $item['assigned']) . "(" . $oinfo['name'] . ")";
@@ -3391,11 +3392,11 @@ function autoPopulateUCS()
 		elseif ($item['type'] == 'ComputeRackUnit')
 		{
 			if ($item['assigned'] == '')
-				$new_object_id = commitAddObject ($mname, NULL, 4, NULL);
+				$new_object_id = commitAddObject ($mname, NULL, 4, NULL, NULL, $disable_autoports);
 			else
 			{
 				$spname = preg_replace ('#.+/ls-(.+)#i', '${1}', $item['assigned']) . "(" . $oinfo['name'] . ")";
-				$new_object_id = commitAddObject ($spname, NULL, 4, NULL);
+				$new_object_id = commitAddObject ($spname, NULL, 4, NULL, NULL, $disable_autoports);
 			}
 			# Set H/W Type for RackmountServer
 			if (array_key_exists ($item['model'], $ucsproductmap))


### PR DESCRIPTION
Added optional 6th parameter to commitAddObject to allow disabling calling the executeAutoPorts function which creates the AUTOPORTS (e.g. kvm, eth0, eth1)
Initially this will be used by the autoPopulateUCS function, since it will populate each server object with the actual ports defined