### PR TITLE
Added function commitRelabelObject()

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -986,6 +986,23 @@ function commitRenameObject ($object_id, $new_name)
 	recordObjectHistory ($object_id);
 }
 
+function commitRelabelObject ($object_id, $new_label)
+{
+	usePreparedUpdateBlade
+	(
+		'Object',
+		array
+		(
+			'label' => nullIfEmptyStr ($new_label),
+		),
+		array
+		(
+			'id' => $object_id
+		)
+	);
+	recordObjectHistory ($object_id);
+}
+
 function commitUpdateObject ($object_id, $new_name, $new_label, $new_has_problems, $new_asset_no, $new_comment)
 {
 	$type_id = getObjectType ($object_id);


### PR DESCRIPTION
There was no existing function to only change an object's label.
commitUpdateObject() required passing all current values for name, label, has_problems, asset_no and comment or they would get set to NULL.