### PR TITLE
snmp.php: use showError instead of showFuncMessage

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -1993,13 +1993,9 @@ function showMessageOrError ()
 		154 => array ('code' => 'error', 'format' => "Verification error: %s"),
 		155 => array ('code' => 'error', 'format' => 'Save failed.'),
 		159 => array ('code' => 'error', 'format' => 'Permission denied moving port %s from VLAN%u to VLAN%u'),
-		161 => array ('code' => 'error', 'format' => 'Endpoint not found. Please either set FQDN attribute or assign an IP address to the object.'),
-		162 => array ('code' => 'error', 'format' => 'More than one IP address is assigned to this object, please configure FQDN attribute.'),
 		170 => array ('code' => 'error', 'format' => 'There is no network for IP address "%s"'),
 		172 => array ('code' => 'error', 'format' => 'Malformed request'),
 		179 => array ('code' => 'error', 'format' => 'Expired form has been declined.'),
-		188 => array ('code' => 'error', 'format' => "Fatal SNMP failure"),
-		189 => array ('code' => 'error', 'format' => "Unknown OID '%s'"),
 		191 => array ('code' => 'error', 'format' => "deploy was blocked due to conflicting configuration versions"),
 
 // records 200~299 with warnings

--- a/wwwroot/inc/snmp.php
+++ b/wwwroot/inc/snmp.php
@@ -4043,18 +4043,17 @@ function checkPIC ($port_type_id)
 
 function doSNMPmining ($object_id, $snmpsetup)
 {
-	setFuncMessages (__FUNCTION__, array ('ERR1' => 161, 'ERR2' => 162));
 	$objectInfo = spotEntity ('object', $object_id);
 	$objectInfo['attrs'] = getAttrValues ($object_id);
 	$endpoints = findAllEndpoints ($object_id, $objectInfo['name']);
 	if (count ($endpoints) == 0)
 	{
-		showFuncMessage (__FUNCTION__, 'ERR1'); // endpoint not found
+		showError ('Endpoint not found. Please either set FQDN attribute or assign an IP address to the object.');
 		return;
 	}
 	if (count ($endpoints) > 1)
 	{
-		showFuncMessage (__FUNCTION__, 'ERR2'); // can't pick an address
+		showError ('More than one IP address is assigned to this object, please configure FQDN attribute.');
 		return;
 	}
 
@@ -4073,18 +4072,17 @@ function doSNMPmining ($object_id, $snmpsetup)
 
 function doSwitchSNMPmining ($objectInfo, $device)
 {
-	setFuncMessages (__FUNCTION__, array ('ERR3' => 188, 'ERR4' => 189));
 	global $known_switches, $iftable_processors;
 
 	if (FALSE === ($sysObjectID = $device->snmpget ('sysObjectID.0')))
 	{
-		showFuncMessage (__FUNCTION__, 'ERR3'); // // fatal SNMP failure
+		showError ('Fatal SNMP failure');
 		return;
 	}
 	$sysObjectID = preg_replace ('/^.*( \.1\.3\.6\.1\.|enterprises\.|joint-iso-ccitt\.)([\.[:digit:]]+)$/', '\\2', $sysObjectID);
 	if (!isset ($known_switches[$sysObjectID]))
 	{
-		showFuncMessage (__FUNCTION__, 'ERR4', array ($sysObjectID)); // unknown OID
+		showError ("Unknown OID '{$sysObjectID}'");
 		return;
 	}
 	$sysName = substr ($device->snmpget ('sysName.0'), strlen ('STRING: '));


### PR DESCRIPTION
now snmp.php can be included in script mode, not only in ophandler
context