### PR TITLE
more ubiquiti and sharing sysObjectID between devices

### DIFF
--- a/wwwroot/inc/definitions/ubiquiti.php
+++ b/wwwroot/inc/definitions/ubiquiti.php
@@ -14,12 +14,12 @@ $ubiquiti_switches = array(
 "EdgeSwitch 16-Port 10G" => array(
  'dict_key' => 2625,
  'text' => 'Ubiquiti EdgeSwitch ES-16-XG',
- 'processors' => array ('ubiquiti-chassis-51-to-52-1000SFP','ubiquiti-chassis-any-1000T','ubiquiti-chassis-any-SFP+')
+ 'processors' => array ('ubiquiti-chassis-13-to-16-10GBASE-T','ubiquiti-chassis-any-SFP+')
 ), 
 "EdgeSwitch 48-Port Lite" => array(
  'dict_key' => 2624,
  'text' => 'Ubiquiti EdgeSwitch ES-48-LITE',
- 'processors' => array ('ubiquiti-chassis-13-to-16-10GBASE-T','ubiquiti-chassis-any-SFP+')
+ 'processors' => array ('ubiquiti-chassis-51-to-52-1000SFP','ubiquiti-chassis-any-1000T','ubiquiti-chassis-any-SFP+')
 ));
 
 if (!isset($switch_model_lookup))

--- a/wwwroot/inc/definitions/ubiquiti.php
+++ b/wwwroot/inc/definitions/ubiquiti.php
@@ -1,0 +1,32 @@
+<?php
+
+# This file is a part of RackTables, a datacenter and server room management
+# framework. See accompanying file "COPYING" for the full copyright and
+# licensing information.
+
+/*
+*
+*  This file is a definitions file for Ubiquiti devices.
+*
+*/
+
+$ubiquiti_switches = array(
+"EdgeSwitch 16-Port 10G" => array(
+ 'dict_key' => 2625,
+ 'text' => 'Ubiquiti EdgeSwitch ES-16-XG',
+ 'processors' => array ('ubiquiti-chassis-51-to-52-1000SFP','ubiquiti-chassis-any-1000T','ubiquiti-chassis-any-SFP+')
+), 
+"EdgeSwitch 48-Port Lite" => array(
+ 'dict_key' => 2624,
+ 'text' => 'Ubiquiti EdgeSwitch ES-48-LITE',
+ 'processors' => array ('ubiquiti-chassis-13-to-16-10GBASE-T','ubiquiti-chassis-any-SFP+')
+));
+
+if (!isset($switch_model_lookup))
+{
+  $switch_model_lookup = array();
+}
+
+$switch_model_lookup['ubiquiti'] = $ubiquiti_switches;
+
+?>

--- a/wwwroot/inc/dictionary.php
+++ b/wwwroot/inc/dictionary.php
@@ -2513,6 +2513,7 @@ $dictionary = array
 	2622 => array ('chapter_id' => 13, 'dict_value' => 'Xen Hypervisor%GSKIP%XenServer 7.0'),
 	2623 => array ('chapter_id' => 18, 'dict_value' => 'HP StorageWorks P6300'),
 	2624 => array ('chapter_id' => 12, 'dict_value' => 'Ubiquiti EdgeSwitch ES-48-LITE'),
+	2625 => array ('chapter_id' => 12, 'dict_value' => 'Ubiquiti EdgeSwitch ES-16-XG'),
 
 # Any new "default" dictionary records must go above this line (i.e., with
 # dict_key code less, than 50000). This is necessary to keep AUTO_INCREMENT

--- a/wwwroot/inc/functions.php
+++ b/wwwroot/inc/functions.php
@@ -6519,4 +6519,31 @@ function syncObjectPorts ($objectInfo, $desiredPorts)
 	showSuccess ("Added ports: {$added}, changed: {$changed}, deleted: {$deleted}");
 }
 
+// searches array of model descriptions for switches from vendor that share OID
+// $manufacturer is defined in the $known_switches array
+// $description is from the sysDescr
+function multi_model_lookup($manufacturer=false, $description=false)
+{
+	if ($manufacturer === false || $description === false)
+	{
+		return false;
+	}
+	$filePath = implode(DIRECTORY_SEPARATOR, array(dirname(__FILE__),'definitions',"{$manufacturer}.php"));
+	if (!file_exists($filePath))
+	{
+		return false;
+	}
+	include $filePath;
+	
+	foreach($switch_model_lookup[$manufacturer] as $key=>$array)
+	{
+		$pos = strpos($description, $key);
+		if ($pos !== false)
+		{
+			return $array;
+		}
+	}
+	return false;
+}
+
 ?>

--- a/wwwroot/inc/snmp.php
+++ b/wwwroot/inc/snmp.php
@@ -2096,6 +2096,15 @@ $iftable_processors['ubiquiti-chassis-51-to-52-1000SFP'] = array
 	'try_next_proc' => FALSE,
 );
 
+$iftable_processors['ubiquiti-chassis-13-to-16-10GBASE-T'] = array
+(
+	'pattern' => '@^Slot: (\d+) Port: (13|14|15|16) 10G - Level$@',
+	'replacement' => '\\1/\\2',
+	'dict_key' => '1642',
+	'label' => '\\2',
+	'try_next_proc' => FALSE,
+);
+
 global $known_switches;
 $known_switches = array // key is system OID w/o "enterprises" prefix
 (
@@ -4006,9 +4015,7 @@ $known_switches = array // key is system OID w/o "enterprises" prefix
 	),
 	'4413' => array
 	(
-		'dict_key' => 2624,
-		'text' => 'Ubiquiti EdgeSwitch ES-48-LITE',
-		'processors' => array ('ubiquiti-chassis-51-to-52-1000SFP','ubiquiti-chassis-any-1000T','ubiquiti-chassis-any-SFP+'),
+		'model_lookup' => 'ubiquiti',
 	),
 );
 
@@ -4126,6 +4133,15 @@ function doSwitchSNMPmining ($objectInfo, $device)
 	$sysName = substr ($device->snmpget ('sysName.0'), strlen ('STRING: '));
 	$sysDescr = substr ($device->snmpget ('sysDescr.0'), strlen ('STRING: '));
 	$sysDescr = str_replace (array ("\n", "\r"), " ", $sysDescr);  // Make it one line
+	if (array_key_exists("model_lookup", $known_switches[$sysObjectID]))
+	{
+		if (FALSE === ($switchObject = multi_model_lookup($known_switches[$sysObjectID]['model_lookup'], $sysDescr)))
+		{
+			showError ("Unknown Model for OID '{$sysObjectID}'");
+			return;
+		}
+		$known_switches[$sysObjectID] = $switchObject;				
+	}
 	$ifDescr_tablename = array_fetch ($known_switches[$sysObjectID], 'ifDescrOID', 'ifDescr');
 	showSuccess ($known_switches[$sysObjectID]['text']);
 	foreach (array_keys ($known_switches[$sysObjectID]['processors']) as $pkey)


### PR DESCRIPTION
I think I committed my previous PR #184 too soon.

I just got a different model Ubiquiti switch and noticed they have the same sysObjectID.  

```# snmpwalk -On -v 2c -c ** 172.20.10.20 sysObjectID.0
.1.3.6.1.2.1.1.2.0 = OID: .1.3.6.1.4.1.4413
# snmpwalk -On -v 2c -c ** 10.10.14.196 sysObjectID.0
.1.3.6.1.2.1.1.2.0 = OID: .1.3.6.1.4.1.4413

# snmpwalk -On -v 2c -c ** 172.20.10.20 sysDescr.0
.1.3.6.1.2.1.1.1.0 = STRING: EdgeSwitch 48-Port Lite, 1.6.0.4900860, Linux 3.6.5-f4a26ed5, 1.0.0.4857129
# snmpwalk -On -v 2c -c public 10.10.14.196 sysDescr.0
.1.3.6.1.2.1.1.1.0 = STRING: EdgeSwitch 16-Port 10G, 1.6.0.4900860, Linux 3.6.5, 1.0.0.4872137
```
So I hacked up the code a bit and added what I think could work in this situation for any manufacturer.  I do know that I tried to make it manufacturer agnostic and the code does work fine.