### PR TITLE
Use getimagesizefromstring() to get image size

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -5194,9 +5194,14 @@ function getFilePreviewCode ($file)
 		case 'image/png':
 		case 'image/gif':
 			$file = getFile ($file['id']);
-			$image = imagecreatefromstring ($file['contents']);
-			$width = imagesx ($image);
-			$height = imagesy ($image);
+			if (function_exists ('getimagesizefromstring'))
+				list ($width, $height) = getimagesizefromstring ($file['contents']);
+			else
+			{
+				$image = imagecreatefromstring ($file['contents']);
+				$width = imagesx ($image);
+				$height = imagesy ($image);
+			}
 			if ($width < getConfigVar ('PREVIEW_IMAGE_MAXPXS') && $height < getConfigVar ('PREVIEW_IMAGE_MAXPXS'))
 				$resampled = FALSE;
 			else


### PR DESCRIPTION
Speed up pages with image files preview.
In my case a rack page with 14 images was taking 5 seconds to load.
With this change load time dropped to 300ms.

This problem has been discussed in 2011: https://www.freelists.org/post/racktables-users/Image-Caching-slow-load-on-displaying-rack-with-tagged-files