### PR TITLE
Update interfaces.php (fixed logout bug on IE and Edge)

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -116,7 +116,7 @@ function renderInterfaceHTML ($pageno, $tabno, $payload)
 <body>
 <div class="maintable">
  <div class="mainheader">
-  <div style="float: right" class=greeting><a href='index.php?page=myaccount&tab=default'><?php global $remote_displayname; echo $remote_displayname ?></a> [ <a href='<?php showLogoutURL(); ?>'>logout</a> ]</div>
+  <div style="float: right" class=greeting><a href='index.php?page=myaccount&tab=default'><?php global $remote_displayname; echo $remote_displayname ?></a> [ <a onclick="document.execCommand('ClearAuthenticationCache');" href='<?php showLogoutURL(); ?>'>logout</a> ]</div>
  <?php echo getConfigVar ('enterprise') ?> RackTables <a href="http://racktables.org" title="Visit RackTables site"><?php echo CODE_VERSION ?></a><?php renderQuickLinks() ?>
  </div>
  <div class="menubar"><?php showPathAndSearch ($pageno, $tabno); ?></div>


### PR DESCRIPTION
On MS IE and Edge it's impossible to pass username and password in URL, in basic HTTP Authentication. So this way of logging out (submit wrong username/password) doesn't work on IE and Edge.
In order to log out, in IE and Edge, it is necessary to clear authentication cache.