### PR TITLE
resolve ambiguous port types in selectbox

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 	update: improve SNMP support for Brocade devices (GH#180 by Chris Jones)
 	update: imply %u for port labels too (Mantis#1739 by Gianluca Laudano)
 	update: switch the Cisco UCS gateway to the new API (by Brian Pothier)
+	update: display port inner type when port outer type is ambiguous in Object's "Ports" tab
 0.20.12 2017-02-08
 	bugfix: common name for blade server(utf-8) was shown incorrectly in racks (by Artem Yankovskiy)
 	bugfix: throwing a undeclared 'ParseError' exception from RackCode parser

--- a/wwwroot/inc/functions.php
+++ b/wwwroot/inc/functions.php
@@ -3347,6 +3347,14 @@ function getUnlinkedPortTypeOptions ($port_iif_id)
 		return $cache[$port_iif_id];
 
 	$ret = array();
+	$seen_oifs = array();
+	$ambiguous_oifs = array();
+	foreach ($compat as $row)
+	{
+		if (isset ($seen_oifs[$row['oif_id']]))
+			$ambiguous_oifs[$row['oif_id']] = 1;
+		$seen_oifs[$row['oif_id']] = 1;
+	}
 	foreach ($compat as $row)
 	{
 		if ($row['iif_id'] == $prefs['iif_pick'] || $row['iif_id'] == $port_iif_id)
@@ -3357,7 +3365,11 @@ function getUnlinkedPortTypeOptions ($port_iif_id)
 			continue;
 		if (!array_key_exists ($optgroup, $ret))
 			$ret[$optgroup] = array();
-		$ret[$optgroup][$row['iif_id'] . '-' . $row['oif_id']] = $row['oif_name'];
+		if (isset ($ambiguous_oifs[$row['oif_id']]) && $optgroup == 'other')
+			$name = $row['iif_name'] . ' / ' . $row['oif_name'];
+		else
+			$name = $row['oif_name'];
+		$ret[$optgroup][$row['iif_id'] . '-' . $row['oif_id']] = $name;
 	}
 
 	$cache[$port_iif_id] = $ret;


### PR DESCRIPTION
add port inner type prefix into a select box when outer type is ambiguous.
ex. inner types "QSFP+" and "QSFP28" have the same "empty QSFP" outer
type