### PR TITLE
Add a new attribute type, text.

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -3326,6 +3326,9 @@ function searchByAttrValue ($attr_id, $value)
 		case 'float':
 			$field = 'float_value';
 			break;
+		case 'text':
+			$field = "text_value";
+			break;
 		case 'uint':
 		case 'dict':
 		case 'date':
@@ -3737,7 +3740,7 @@ function fetchAttrsForObjects ($object_set = array())
 	$ret = array();
 	$query =
 		"select AM.attr_id, A.name as attr_name, A.type as attr_type, C.name as chapter_name, " .
-		"C.id as chapter_id, AV.uint_value, AV.float_value, AV.string_value, D.dict_value, O.id as object_id from " .
+		"C.id as chapter_id, AV.uint_value, AV.float_value, AV.string_value, AV.text_value, D.dict_value, O.id as object_id from " .
 		"Object as O left join AttributeMap as AM on O.objtype_id = AM.objtype_id " .
 		"left join Attribute as A on AM.attr_id = A.id " .
 		"left join AttributeValue as AV on AV.attr_id = AM.attr_id and AV.object_id = O.id " .
@@ -3770,6 +3773,7 @@ function fetchAttrsForObjects ($object_set = array())
 				// fall through
 			case 'uint':
 			case 'float':
+			case 'text':
 			case 'string':
 				$record['value'] = $row[$row['attr_type'] . '_value'];
 				parseWikiLink ($record);
@@ -3829,7 +3833,7 @@ function commitUpdateAttrValue ($object_id, $attr_id, $value = '')
 		unset ($object_attribute_cache[$object_id]);
 	$result = usePreparedSelectBlade
 	(
-		'SELECT A.type AS attr_type, AV.attr_id, AV.uint_value, AV.float_value, AV.string_value ' .
+		'SELECT A.type AS attr_type, AV.attr_id, AV.uint_value, AV.float_value, AV.string_value, AV.text_value ' .
 		'FROM Attribute AS A ' .
 		'LEFT JOIN AttributeValue AS AV ON A.id = AV.attr_id AND AV.object_id = ? ' .
 		'WHERE A.id = ?',
@@ -3843,6 +3847,7 @@ function commitUpdateAttrValue ($object_id, $attr_id, $value = '')
 	{
 		case 'uint':
 		case 'float':
+		case 'text':
 		case 'string':
 			$column = $attr_type . '_value';
 			break;

--- a/wwwroot/inc/functions.php
+++ b/wwwroot/inc/functions.php
@@ -301,6 +301,10 @@ function genericAssertion ($argname, $argtype)
 		return assertStringArg ($argname);
 	case 'string0':
 		return assertStringArg ($argname, TRUE);
+	case 'text':
+		return assertStringArg ($argname);
+	case 'text0':
+		return assertStringArg ($argname, TRUE);
 	case 'uint':
 		return assertUIntArg ($argname);
 	case 'uint0':
@@ -371,7 +375,7 @@ function genericAssertion ($argname, $argtype)
 		return $argvalue;
 	case 'enum/attr_type':
 		assertStringArg ($argname);
-		if (!in_array ($sic[$argname], array ('uint', 'float', 'string', 'dict','date')))
+		if (!in_array ($sic[$argname], array ('uint', 'float', 'string', 'text', 'dict','date')))
 			throw new InvalidRequestArgException ($argname, $sic[$argname], 'Unknown value');
 		return $sic[$argname];
 	case 'enum/vlan_type':

--- a/wwwroot/inc/install.php
+++ b/wwwroot/inc/install.php
@@ -501,7 +501,7 @@ function get_pseudo_file ($name)
 
 		$query[] = "CREATE TABLE `Attribute` (
   `id` int(10) unsigned NOT NULL auto_increment,
-  `type` enum('string','uint','float','dict','date') default NULL,
+  `type` enum('string','text','uint','float','dict','date') default NULL,
   `name` char(64) default NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`)
@@ -526,6 +526,7 @@ function get_pseudo_file ($name)
   `object_tid` int(10) unsigned NOT NULL default '0',
   `attr_id` int(10) unsigned NOT NULL,
   `string_value` char(255) default NULL,
+  `text_value` text,
   `uint_value` int(10) unsigned default NULL,
   `float_value` float default NULL,
   PRIMARY KEY (`object_id`,`attr_id`),

--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -66,6 +66,7 @@ $localreports = array();
 $attrtypes = array
 (
 	'uint' => '[U] unsigned integer',
+        'text' => '[R] text',
 	'float' => '[F] floating point',
 	'string' => '[S] string',
 	'dict' => '[D] dictionary record',
@@ -768,6 +769,8 @@ function renderEditRowForm ($row_id)
 			case 'string':
 				echo "<input type=text name=${i}_value value='${record['value']}'>";
 				break;
+			case 'text':
+				echo "<textarea rows=5 cols=42 name=${i}_value>${record['value']}</textarea>";
 			case 'dict':
 				$chapter = readChapter ($record['chapter_id'], 'o');
 				$chapter[0] = '-- NOT SET --';
@@ -1141,6 +1144,9 @@ function renderEditObjectForm()
 				case 'string':
 					echo "<input type=text name=${i}_value value='${record['value']}'>";
 					break;
+				case 'text':
+                                        echo "<textarea rows=5 cols=42 name=${i}_value>${record['value']}</textarea>";
+                                        break;
 				case 'dict':
 					$chapter = readChapter ($record['chapter_id'], 'o');
 					$chapter[0] = '-- NOT SET --';
@@ -1230,6 +1236,9 @@ function renderEditRackForm ($rack_id)
 			case 'float':
 			case 'string':
 				echo "<input type=text name=${i}_value value='${record['value']}'>";
+				break;
+			case 'text':
+				echo "<textarea name=${i}_value rows=5 cols=42>${record['value']}</textarea>";
 				break;
 			case 'dict':
 				$chapter = readChapter ($record['chapter_id'], 'o');
@@ -4061,6 +4070,9 @@ function renderEditLocationForm ($location_id)
 			case 'float':
 			case 'string':
 				echo "<input type=text name=${i}_value value='${record['value']}'>";
+				break;
+			case 'text':
+				echo "<textarea rows=5 cols=42 name=${i}_value>${record['value']}</textarea>";
 				break;
 			case 'dict':
 				$chapter = readChapter ($record['chapter_id'], 'o');

--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -1408,6 +1408,7 @@ function updateObjectAttributes ($object_id)
 			case 'uint':
 			case 'float':
 			case 'string':
+			case 'text':
 			case 'date':
 				$oldvalue = $oldvalues[$attr_id]['value'];
 				break;

--- a/wwwroot/inc/upgrade.php
+++ b/wwwroot/inc/upgrade.php
@@ -1226,6 +1226,8 @@ ENDOFTRIGGER;
 			break;
 		// FIXME: add remaining 0.20.x sections here after respective releases come out
 		case '0.21.0':
+			$query[] = "ALTER TABLE Attribute CHANGE type type ENUM('string','text','uint','float','dict','date') NULL DEFAULT NULL";
+			$query[] = "ALTER TABLE AttributeValue ADD COLUMN `text_value` text AFTER `string_value`";
 			$query[] = "UPDATE Port SET label = NULL WHERE label = ''";
 			$query[] = "UPDATE Config SET varvalue = '0.21.0' WHERE varname = 'DB_VERSION'";
 			break;


### PR DESCRIPTION
A feature I cooked up on top of 0.20.13 to make RackTables a bit more useful in regards to storing data in one place and using it many places through syncing data from the RackTables database to other sources, such as Icinga2's Director and other tools that want a bit more than a varchar.
This way it is one pane in RackTables to override / add custom data to the objects in RackTables as an authorative source for all configuration items.