### PR TITLE
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'color' in 'fi…

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -4314,7 +4314,7 @@ function getTagList ($extra_sql = '')
 {
 	$result = usePreparedSelectBlade
 	(
-		'SELECT id, parent_id, is_assignable, tag, LPAD(HEX(color), 6, "0") AS color ' .
+		'SELECT id, parent_id, is_assignable, tag, LPAD(HEX(color), 6, "0") AS color ' . // But there is no column 'color' in the TagTree table...
 		"FROM TagTree ORDER BY tag ${extra_sql}"
 	);
 	return reindexById ($result->fetchAll (PDO::FETCH_ASSOC));
@@ -6124,7 +6124,7 @@ function releaseDBMutex ($name)
 function getPlugins ($state = NULL)
 {
 	// installed
-	$result = usePreparedSelectBlade ('SELECT name, longname, version, home_url, state FROM Plugin ORDER BY name');
+	$result = usePreparedSelectBlade ('SELECT name, longname, version, home_url, state FROM Plugin ORDER BY name'); // But Plugin table does not exist at all...
 	$in_db = array ();
 	foreach ($result as $row)
 		if (! $state or $state == $row['state'])


### PR DESCRIPTION
…eld list' (42S22)?

Hello colleagues!
If in the project uses a blade chassis, then after authorization on the racktables-site we get the PDOException error from function getTagList:
============================
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'color' in 'field list' (42S22)
at file /var/www/rackTables/inc/database.php, line 4034

/var/www/rackTables/inc/database.php:4034 execute(Array
(
)
)
/var/www/rackTables/inc/database.php:4318 usePreparedSelectBlade('SELECT id, parent_id, is_assignable, tag, LPAD(HEX(color), 6, "0") AS color FROM TagTree ORDER BY tag ')
/var/www/rackTables/inc/init.php:99 getTagList()
/var/www/rackTables/index.php:21 require_once('/var/www/rackTables/inc/init.php')
Error info:

Array
(
    [0] => 42S22
    [1] => 1054
    [2] => Unknown column 'color' in 'field list'
)
============================
...and...
============================
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'racktables_db.Plugin' doesn't exist (42S02)
at file /var/www/rackTables/inc/database.php, line 4034

/var/www/rackTables/inc/database.php:4034 execute(Array
(
)
)
/var/www/rackTables/inc/database.php:6128 usePreparedSelectBlade('SELECT name, longname, version, home_url, state FROM Plugin ORDER BY name')
/var/www/rackTables/inc/init.php:159 getPlugins('enabled')
/var/www/rackTables/index.php:21 require_once('/var/www/rackTables/inc/init.php')
Error info:

Array
(
    [0] => 42S02
    [1] => 1146
    [2] => Table 'racktables_db.Plugin' doesn't exist
)
============================

Since there is no column 'color' in the TagTree table, and the Plugin table does not exist at all.

Very thanks for the support.