### PR TITLE
"shared router" allocation to support VRRP and alike

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 	update: 802.1Q: foreign VLANs (missing from the vlan domain list) are not propagated to uplinks
 	update: ability to extend supported device breed list via plug-in
 	update: add a server configuration report (same as before install/upgrade)
+        new feature: "shared router" allocation (GH#210 by Vladimir Ivanov)
 0.21.1 2017-10-22
 	update: improve Percona server support (Mantis#1793)
 	bugfix: fix an upgrade bug introduced in 0.21.0 (found by Chris James)

--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -2144,7 +2144,7 @@ function scanIPv4Space ($pairlist, $filter_flags = IPSCAN_ANY)
 	if ($filter_flags & IPSCAN_DO_ALLOCS)
 	{
 	if ($filter_flags & IPSCAN_RTR_ONLY)
-		$whereexpr2 .= " AND ia.type = 'router'";
+		$whereexpr2 .= " AND ( ia.type = 'router' OR ia.type = 'sharedrouter')";
 	$query =
 		"select ia.ip, ia.object_id, ia.name, ia.type, Object.name as object_name " .
 		"from IPv4Allocation AS ia INNER JOIN Object ON ia.object_id = Object.id where ${whereexpr2} order by ia.type";
@@ -2354,7 +2354,7 @@ function scanIPv6Space ($pairlist, $filter_flags = IPSCAN_ANY)
 	if ($filter_flags & IPSCAN_DO_ALLOCS)
 	{
 	if ($filter_flags & IPSCAN_RTR_ONLY)
-		$whereexpr2 .= " AND ia.type = 'router'";
+		$whereexpr2 .= " AND (ia.type = 'router' OR ia.type = 'sharedrouter')";
 	$query =
 		"select ia.ip, ia.object_id, ia.name, ia.type, Object.name as object_name " .
 		"from IPv6Allocation AS ia INNER JOIN Object ON ia.object_id = Object.id where ${whereexpr2} order by ia.type";

--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -24,6 +24,7 @@ $aat = array
 	'virtual' => 'Loopback',
 	'shared' => 'Shared',
 	'router' => 'Router',
+	'sharedrouter' => 'Shared router',
 	'point2point' => 'Point-to-point',
 );
 // address allocation code, IPv4 addresses and objects view
@@ -33,6 +34,7 @@ $aac_right = array
 	'virtual' => '<span class="aac-right" title="' . $aat['virtual'] . '">L</span>',
 	'shared' => '<span class="aac-right" title="' . $aat['shared'] . '">S</span>',
 	'router' => '<span class="aac-right" title="' . $aat['router'] . '">R</span>',
+	'sharedrouter' => '<span class="aac-right" title="' . $aat['sharedrouter'] . '">R</span>',
 	'point2point' => '<span class="aac-right" title="' . $aat['point2point'] . '">P</span>',
 );
 // address allocation code, IPv4 networks view
@@ -42,6 +44,7 @@ $aac_left = array
 	'virtual' => '<span class="aac-left" title="' . $aat['virtual'] . '">L:</span>',
 	'shared' => '<span class="aac-left" title="' . $aat['shared'] . '">S:</span>',
 	'router' => '<span class="aac-left" title="' . $aat['router'] . '">R:</span>',
+	'sharedrouter' => '<span class="aac-left" title="' . $aat['sharedrouter'] . '">R:</span>',
 	'point2point' => '<span class="aac-left" title="' . $aat['point2point'] . '">P:</span>',
 );
 
@@ -3039,7 +3042,7 @@ function renderIPv4NetworkAddresses ($range)
 		{
 			echo $delim . $aac_left[$ref['type']];
 			echo makeIPAllocLink ($ip_bin, $ref, TRUE);
-			$delim = '; ';
+			$delim = ';<br/>';
 		}
 		if ($delim != '')
 			$delim = '<br>';
@@ -3164,7 +3167,7 @@ function renderIPv6NetworkAddresses ($netinfo)
 		{
 			echo $delim . $aac_left[$ref['type']];
 			echo makeIPAllocLink ($ip_bin, $ref, TRUE);
-			$delim = '; ';
+			$delim = ';<br/>';
 		}
 		if ($delim != '')
 			$delim = '<br>';

--- a/wwwroot/inc/upgrade.php
+++ b/wwwroot/inc/upgrade.php
@@ -173,6 +173,10 @@ after the upgrade, try disabling plugins.
 Refer to <a href="http://wiki.racktables.org/index.php/Plugins">the wiki</a> for more information.
 ENDOFTEXT
 ,
+	'0.21.2' => <<<'ENDOFTEXT'
+"Shared router" allocation type introduced, useful for documenting VRRP-protected addresses.
+ENDOFTEXT
+,
 );
 
 // At the moment we assume that for any two releases we can
@@ -1307,6 +1311,8 @@ INSERT INTO `Config` (varname, varvalue, vartype, emptyok, is_hidden, is_userdef
 			$query[] = "ALTER TABLE MountOperation DROP KEY `MountOperation-FK-old_molecule_id`";
 			$query[] = "ALTER TABLE MountOperation DROP KEY `MountOperation-FK-new_molecule_id`";
 			$query[] = "UPDATE Config SET varvalue = '0.21.2' WHERE varname = 'DB_VERSION'";
+			$query[] = "ALTER TABLE IPv4Allocation MODIFY TYPE ENUM('regular','shared','virtual','router','point2point', 'sharedrouter') NOT NULL DEFAULT 'regular';";
+			$query[] = "ALTER TABLE IPv6Allocation MODIFY TYPE ENUM('regular','shared','virtual','router','point2point', 'sharedrouter') NOT NULL DEFAULT 'regular';";
 			break;
 		case 'dictionary':
 			$query = reloadDictionary();


### PR DESCRIPTION
Introducing new "Shared router" allocation.

It is useful to document VRRP/CARP/HSRP kind of IP addresses. This allocation combines the properties of "router" and "shared" allocations, i.e.
- such IPs are shown in "routed by" sections
- such IPs do not conflict between each other (but conflict with all other allocations)