### PR TITLE
Add latest openSUSE Leap and SUSE Linux Enterprise distributions

### DIFF
--- a/wwwroot/inc/dictionary.php
+++ b/wwwroot/inc/dictionary.php
@@ -3576,8 +3576,8 @@ $dictionary = array
 	3684 => array ('chapter_id' => 12, 'dict_value' => 'Arista%GPASS%7280SR2A-48YC6'),
 	3685 => array ('chapter_id' => 12, 'dict_value' => 'MikroTik%GPASS%CRS112-8P-4S-IN'),
 	3686 => array ('chapter_id' => 13, 'dict_value' => 'Ubuntu%GSKIP%Ubuntu 17.10'),
-    3687 => array ('chapter_id' => 13, 'dict_value' => 'SUSE Enterprise%GSKIP%SLES15'),
-    3688 => array ('chapter_id' => 13, 'dict_value' => 'OpenSUSE%GSKIP%openSUSE Leap 15.x'),
+	3687 => array ('chapter_id' => 13, 'dict_value' => 'SUSE Enterprise%GSKIP%SLES15'),
+	3688 => array ('chapter_id' => 13, 'dict_value' => 'OpenSUSE%GSKIP%openSUSE Leap 15.x'),
 
 
 # Any new "default" dictionary records must go above this line (i.e., with

--- a/wwwroot/inc/dictionary.php
+++ b/wwwroot/inc/dictionary.php
@@ -3576,6 +3576,8 @@ $dictionary = array
 	3684 => array ('chapter_id' => 12, 'dict_value' => 'Arista%GPASS%7280SR2A-48YC6'),
 	3685 => array ('chapter_id' => 12, 'dict_value' => 'MikroTik%GPASS%CRS112-8P-4S-IN'),
 	3686 => array ('chapter_id' => 13, 'dict_value' => 'Ubuntu%GSKIP%Ubuntu 17.10'),
+    3687 => array ('chapter_id' => 13, 'dict_value' => 'SUSE Enterprise%GSKIP%SLES15'),
+    3688 => array ('chapter_id' => 13, 'dict_value' => 'OpenSUSE%GSKIP%openSUSE Leap 15.x'),
 
 
 # Any new "default" dictionary records must go above this line (i.e., with


### PR DESCRIPTION
SUSE Linux Enterprise 15.0 as well as openSUSE Leap 15.0 will be released in a few weeks. The names are already fixed, so I see no reason why they should not appear in the next RackTables release already.