### PR TITLE
Use LDAP Groups as additional Source for Auto-Tags

### DIFF
--- a/wwwroot/inc/auth.php
+++ b/wwwroot/inc/auth.php
@@ -639,6 +639,35 @@ function queryLDAPServer ($username, $password)
 					validTagName ('$lgcn_' . $matches[1], TRUE)
 				)
 					$ret['memberof'][] = '$lgcn_' . $matches[1];
+
+		// Pull group membership based on Group Objects if Group Search DN is given
+        if (isset ($LDAP_options['group_search_dn']))
+        {
+    		// Default values
+    		if (!isset($LDAP_options['group_search_attr']))
+    			$LDAP_options['group_search_attr']= 'cn';
+    		if (!isset($LDAP_options['group_search_member_attr']))
+    			$LDAP_options['ggroup_search_member_attr']= 'memberuid';
+
+            $group_results = @ldap_search
+            (
+                    $connect,
+                    $LDAP_options['group_search_dn'],
+                    '(' . $LDAP_options['group_search_member_attr'] . '='. $username .')',
+                    array($LDAP_options['group_search_attr'], $LDAP_options['group_search_member_attr'])
+            );
+
+            if(@ldap_count_entries ($connect, $group_results) > 0)
+            {
+                   	$groups = @ldap_get_entries($connect, $group_results);
+                    foreach($groups as $group)
+                   	{
+                            $groupName = $group[$LDAP_options['group_search_attr']][0];
+                            $ret['memberof'][] = '$lgcn_' . $groupName;
+                   	}
+            }
+        }
+
 	}
 	@ldap_close ($connect);
 	return $ret;


### PR DESCRIPTION
Currently the memberOf Overlay is used to create Auto-Tags for LDAP Group Membership. With my Code, you can also use LDAP Groups to look for User-Membership.

For this to work you have to set
* group_search_dn to the dn where your Groups are
* group_search_attr, the attribute where Group Name is in, defaults to 'cn'
* group_search_member_attr, Attribute with Array of the Group Members, defaults to 'memberuid'
