### PR TITLE
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'description' …

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -4292,7 +4292,7 @@ function getTagList ($extra_sql = '')
 {
 	$result = usePreparedSelectBlade
 	(
-		'SELECT id, parent_id, is_assignable, tag, LPAD(HEX(color), 6, "0") AS color, description ' .
+		'SELECT id, parent_id, is_assignable, tag, LPAD(HEX(color), 6, "0") AS color ' .
 		"FROM TagTree ORDER BY tag ${extra_sql}"
 	);
 	return reindexById ($result->fetchAll (PDO::FETCH_ASSOC));


### PR DESCRIPTION
…in 'field list' (42S22)

PDOException
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'description' in 'field list' (42S22)
at file /var/www/rackTables/inc/database.php, line 4015

/var/www/rackTables/inc/database.php:4015 execute(Array
(
)
)
/var/www/rackTables/inc/database.php:4296 usePreparedSelectBlade('SELECT id, parent_id, is_assignable, tag, LPAD(HEX(color), 6, "0") AS color, description FROM TagTree ORDER BY tag ')
/var/www/rackTables/inc/init.php:99 getTagList()
/var/www/rackTables/index.php:21 require_once('/var/www/rackTables/inc/init.php')