### PR TITLE
Allow webfonts through CSS

### DIFF
--- a/wwwroot/inc/config.php
+++ b/wwwroot/inc/config.php
@@ -13,4 +13,4 @@ committers' copies) can run into issues:
    have already been executed.
 */
 
-define ('CODE_VERSION', '0.21.1');
+define ('CODE_VERSION', '0.21.2');

--- a/wwwroot/inc/config.php
+++ b/wwwroot/inc/config.php
@@ -13,4 +13,4 @@ committers' copies) can run into issues:
    have already been executed.
 */
 
-define ('CODE_VERSION', '0.21.2');
+define ('CODE_VERSION', '0.21.1');

--- a/wwwroot/inc/solutions.php
+++ b/wwwroot/inc/solutions.php
@@ -455,14 +455,20 @@ function proxyStaticURI ($URI)
 {
 	$content_type = array
 	(
-		'css' => 'text/css',
-		'js' => 'text/javascript',
-		'html' => 'text/html',
-		'png' => 'image/png',
-		'gif' => 'image/gif',
-		'jpg' => 'image/jpeg',
-		'jpeg' => 'image/jpeg',
-		'ico' => 'image/x-icon',
+		'css'   => 'text/css',
+		'js'    => 'text/javascript',
+		'html'  => 'text/html',
+		'png'   => 'image/png',
+		'gif'   => 'image/gif',
+		'jpg'   => 'image/jpeg',
+		'jpeg'  => 'image/jpeg',
+		'ico'   => 'image/x-icon',
+		'eot'   => 'application/vnd.ms-fontobject',
+		'otf'   => 'application/font-sfnt',
+		'svg'   => 'image/svg+xml',
+		'ttf'   => 'application/font-sfnt',
+		'woff'  => 'application/font-woff',
+		'woff2' => 'font/woff2',
 	);
 	$matches = array();
 	if


### PR DESCRIPTION
This pull request permits the use of webfonts through the addCSS/addJS functionality.  This also allows the use of font awesome once modified to use the `?index.php?module=chrome&uri=path/to/webfont` if you want to use a local version.