### PR TITLE
enable ability to predefine connection in secret.php

### DIFF
--- a/wwwroot/inc/init.php
+++ b/wwwroot/inc/init.php
@@ -27,7 +27,15 @@ require_once 'slb.php';
 require_once 'slbv2.php';
 
 // secret.php may be missing, in which case this is a special fatal error
+$isDBInitialised = true;
 if (! fileSearchExists ($path_to_secret_php))
+	$isDBInitialised = false;
+else {
+	connectDB();
+	$isDBInitialised = doesTableExist('Config');
+}
+
+if (!$isDBInitialised)
 	throw new RackTablesError
 	(
 		"This instance of RackTables misses a configuration file " .
@@ -37,7 +45,6 @@ if (! fileSearchExists ($path_to_secret_php))
 		RackTablesError::MISCONFIGURED
 	);
 
-connectDB();
 transformRequestData();
 $configCache = loadConfigDefaults();
 

--- a/wwwroot/inc/install.php
+++ b/wwwroot/inc/install.php
@@ -78,7 +78,9 @@ echo "<input type=hidden name=step value='${next_step}'>\n";
 function not_already_installed()
 {
 	global $found_secret_file, $pdo_dsn;
-	if ($found_secret_file && isset ($pdo_dsn))
+
+	// Do we have a database connection, and a Config table?
+	if ($found_secret_file && isset ($pdo_dsn) && doesTableExist('Config'))
 	{
 		echo 'Your configuration file exists and seems to hold necessary data already.<br>';
 		return FALSE;
@@ -133,6 +135,13 @@ function init_config ()
 		echo '</table>';
 	}
 	global $path_to_secret_php;
+
+	if (try_connect_db ())
+	{
+		echo "Database connectivity seems to be OK.<br>";
+		return TRUE;
+	}
+
 	if (!is_writable ($path_to_secret_php))
 	{
 		echo "The $path_to_secret_php file is not writable by web-server. Make sure it is.";
@@ -334,6 +343,21 @@ function check_config_access()
 	echo 'only as an example):';
 	echo "<pre>chown $uname:nogroup secret.php; chmod 440 secret.php</pre>";
 	return FALSE;
+}
+
+// Similar to connect_to_db_or_die but allow for a
+// TRUE/FALSE return instead of throwing an exception
+function try_connect_db () {
+	try
+	{
+		connectDB();
+		return true;
+	}
+	catch (RackTablesError $e)
+	{
+	}
+
+	return false;
 }
 
 function connect_to_db_or_die ()

--- a/wwwroot/inc/pre-init.php
+++ b/wwwroot/inc/pre-init.php
@@ -103,3 +103,27 @@ function fileSearchExists ($filename)
 	}
 	return file_exists ($filename);
 }
+
+// tries to see if a table is present and returns true/false.
+// needs to be here to be available to both the install and
+// core sections.
+function doesTableExist ($name)
+{
+	global $dbxlink;
+
+	try {
+		if (!isset($dbxlink) || $dbxlink == NULL)
+			connectDB();
+
+		if (!isset($dbxlink) || $dbxlink == NULL)
+			return false;
+
+		$query = 'SHOW TABLES LIKE \'' . $name . '\'';
+		$prepare = $dbxlink->prepare($query);
+		$prepare->execute();
+		$row = $prepare->fetchAll (PDO::FETCH_ASSOC);
+		return !empty($row);
+	} catch (Exception $e) {
+		return false;
+	}
+}


### PR DESCRIPTION
This pull request allows for the scenario when a developer or admin may predefine the secret.php before even running the upgrade script.  Previously, it would fail if predefined and no tables exist with a runtime error.