### PR TITLE
add SNMP support for HP Aruba 2530 48 PoE+ Switch and HP Aruba 2530 24 PoE+ Switch (Mantis#1641)

### DIFF
--- a/wwwroot/inc/dictionary.php
+++ b/wwwroot/inc/dictionary.php
@@ -3615,6 +3615,8 @@ $dictionary = array
 	3718 => array ('chapter_id' => 11, 'dict_value' => 'Dell PowerEdge%GPASS%R330'),
 	3719 => array ('chapter_id' => 11, 'dict_value' => 'Dell PowerEdge%GPASS%R740xd'),
 	3720 => array ('chapter_id' => 14, 'dict_value' => 'HP Procurve OS N.11.78'),
+	3721 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP Aruba 2530 48 PoE+ Switch | https://www.hpe.com/us/en/product-catalog/networking/networking-switches/pip.specifications.aruba-2530-48-poeplus-switch.5384996.html]]'),
+	3722 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP Aruba 2530 24 PoE+ Switch | https://www.hpe.com/uk/en/product-catalog/networking/networking-switches/pip.specifications.aruba-2530-24-poeplus-switch.5384999.html]]'),
 
 # Any new "default" dictionary records must go above this line (i.e., with
 # dict_key code less than 50000). This is necessary to keep AUTO_INCREMENT

--- a/wwwroot/inc/snmp.php
+++ b/wwwroot/inc/snmp.php
@@ -4207,6 +4207,18 @@ $known_switches = array // key is system OID w/o "enterprises" prefix
 		'text' => 'Ubiquiti EdgeSwitch ES-48-LITE',
 		'processors' => array ('ubiquiti-chassis-51-to-52-1000SFP','ubiquiti-chassis-any-1000T','ubiquiti-chassis-any-SFP+'),
 	),
+	'11.2.3.7.11.145' => array
+     (
+         'dict_key' => 3654,
+         'text' => 'HP Aruba 2530 48 PoE+ Switch, (48) RJ-45 10/100 PoE+ ports, (2) autosensing 10/100/1000 ports, (2) fixed Gigabit Ethernet SFP ports',
+         'processors' => array ('procurve-51-to-52-1000SFP','procurve-49-to-50-1000T','procurve-chassis-100TX'),
+     ),
+     '11.2.3.7.11.146' => array
+     (
+         'dict_key' => 3655,
+         'text' => 'HP Aruba 2530 24 PoE+ Switch, (24) RJ-45 10/100 PoE+ ports, (2) autosensing 10/100/1000 ports, (2) fixed Gigabit Ethernet SFP ports',
+         'processors' => array ('procurve-27-to-28-1000SFP','procurve-25-to-26-1000T','procurve-chassis-100TX'),
+     ),
 );
 
 global $swtype_pcre;


### PR DESCRIPTION
add SNMP support for HP Aruba 2530 48 PoE+ Switch and HP Aruba 2530 24 PoE+ Switch (Mantis#1641)