### PR TITLE
Function to handle port-channel interfaces correctly for ios15

### DIFF
--- a/wwwroot/inc/breed-ios15.php
+++ b/wwwroot/inc/breed-ios15.php
@@ -70,3 +70,14 @@ function ios15TranslatePushQueue ($dummy_object_id, $queue, $dummy_vlan_names)
 		}
 	return $ret;
 }
+
+function ios15ShortenIfName_real ($ifname)
+{
+	$ifname = preg_replace ('@^FastEthernet(.+)$@', 'fa\\1', $ifname);
+	$ifname = preg_replace ('@^GigabitEthernet(.+)$@', 'gi\\1', $ifname);
+	$ifname = preg_replace ('@^TenGigabitEthernet(.+)$@', 'te\\1', $ifname);
+	$ifname = preg_replace ('@^po([0-9]+)$@i', 'port-channel\\1', $ifname);
+	$ifname = strtolower ($ifname);
+	$ifname = preg_replace ('/^(fa|gi|te|po)\s+(\d.*)/', '$1$2', $ifname);
+	return $ifname;
+}

--- a/wwwroot/inc/remote.php
+++ b/wwwroot/inc/remote.php
@@ -201,7 +201,7 @@ $breed_by_swcode = array
 
 $shorten_by_breed = array (
 	'ios12' => 'ios12ShortenIfName_real',
-	'ios15' => 'ios12ShortenIfName_real',
+	'ios15' => 'ios15ShortenIfName_real',
 	'nxos4' => 'nxos4ShortenIfName',
 	'vrp53' => 'vrp5xShortenIfName',
 	'vrp55' => 'vrp5xShortenIfName',


### PR DESCRIPTION
Function ios15ShortenIfName_real added to handle port-channel interfaces names correctly: ios15 does not support shorten "po" interface name in case it used in cli view. 