### PR TITLE
add SNMP support for HP Switches

### DIFF
--- a/wwwroot/inc/dictionary.php
+++ b/wwwroot/inc/dictionary.php
@@ -3787,10 +3787,11 @@ $dictionary = array
 	3725 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HPE 5500-24G-4SFP | https://h20195.www2.hpe.com/v2/default.aspx?cc=az&lc=az&oid=5195377]]'),
 	3726 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP A5800AF-48G Switch with 2 Processors (JG225A) | https://www.hpe.com/us/en/product-catalog/networking/networking-switches/pip.specifications.hpe-flexfabric-5800af-48g-switch.7482188.html]]'),
 	3727 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP 1810-8G v2 (J9802A)]]'),
-	// no 3728
+	3728 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP ProCurve Switch 5400zl Series | http://www.hp.com/hpinfo/newsroom/press_kits/2010/HPOptimizesAppDelivery/E5400zl_Switch_Series_Data_Sheet.pdf]]'),
 	3729 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP 1810-8G v2 (J9449A) | https://h10057.www1.hp.com/ecomcat/hpcatalog/specs/provisioner/99/J9449A.htm]]'),
 	3730 => array ('chapter_id' => 12, 'dict_value' => 'HP ProCurve%GPASS%1810G-24 (J9803A)'),
 	3731 => array ('chapter_id' => 12, 'dict_value' => 'Cisco%GPASS%Cisco 871'),
+	3732 => array ('chapter_id' => 12, 'dict_value' => '[[HP%GPASS%HP A5120-24G EI Switch with 2 Interface Slots | [[https://h20195.www2.hpe.com/v2/GetDocument.aspx?docname=c04111657&doctype=quickspecs&doclang=EN_US&searchquery=&cc=za&lc=en]]'),
 
 # Any new "default" dictionary records must go above this line (i.e., with
 # dict_key code less than 50000). This is necessary to keep AUTO_INCREMENT

--- a/wwwroot/inc/snmp.php
+++ b/wwwroot/inc/snmp.php
@@ -2321,6 +2321,24 @@ $iftable_processors['nexus-any-10000T'] = array
 	'try_next_proc' => FALSE,
 );
 
+$iftable_processors['procurve-25-to-28-1000SFPcombo'] = array
+(
+	'pattern' => '@^GigabitEthernet1/0/(25|26|27|28)$@',
+	'replacement' => '\\1',
+	'dict_key' => '4-1077',
+	'label' => '\\1',
+	'try_next_proc' => FALSE,
+);
+
+$iftable_processors['procurve-49-to-52-combo-1000SFP'] = array
+(
+	'pattern' => '@^(49|50|51|52)$@',
+	'replacement' => '\\1',
+	'dict_key' => '4-1077',
+	'label' => '\\1',
+	'try_next_proc' => TRUE,
+);
+
 global $known_switches;
 $known_switches = array // key is system OID w/o "enterprises" prefix
 (
@@ -4402,6 +4420,30 @@ $known_switches = array // key is system OID w/o "enterprises" prefix
 		'dict_key' => 2189,
 		'text' => 'Cisco Catalyst Model WS-C3850-24T, 24 Gigabit Ethernet',
 		'processors' => array ('cisco-25-to-28-1000SFP', 'catalyst-stack-any-1000T'),
+	),
+	'11.2.3.7.11.50' => array
+	(
+		'dict_key' => 3728,
+		'text' => 'HP ProCurve Switch 5400zl Series, RJ-45 48 auto-sensing 10/100/1000 ports',
+		'processors' => array ('procurve-modular-1000T'),
+	),
+	'10.107.158.51' => array
+	(
+		'dict_key' => 3732,
+		'text' => 'HP A5120-24G EI (JE068A),  24 ports 10/100/1000Base-T, 4 Combo ports 10/100/1000Base-T/SFP, 2 interface slots for 10Gbe',
+		'processors' => array ('procurve-25-to-28-1000SFPcombo','procurve-any-1000T'),
+	),
+	'25506.11.1.85' => array
+	(
+		'dict_key' => 2238,
+		'text' => 'JE009A: 48 RJ-45/10-100-1000T(X) + 4 SFP-1000 ports',
+		'processors' => array ('procurve-49-to-52-combo-1000SFP','procurve-modular-1000T'),
+	),
+	'11.2.3.7.11.69' => array
+	(
+		'dict_key' => 872,
+		'text' => ' J9049A: 24 RJ-45/10-100-1000T',
+		'processors' => array ('procurve-chassis-1000T'),
 	),
 );
 


### PR DESCRIPTION
add SNMP support for Hp Procurve 5406zl  (Mantis#1485)
add SNMP support for HP A5120-24G (Mantis#1257)
add SNMP support for HP V1910-48G Switch JE009A (Mantis#1193)
add SNMP support for HP Procurve 2900 (Mantis#689)