### PR TITLE
Make rack table look nicer

### DIFF
--- a/wwwroot/css/normalize.css
+++ b/wwwroot/css/normalize.css
@@ -1,0 +1,349 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+[hidden] {
+  display: none;
+}

--- a/wwwroot/css/pi.css
+++ b/wwwroot/css/pi.css
@@ -16,13 +16,10 @@ td.submit {
 	text-align: center;
 }
 
-th.rack {
-	font: bold 12px Verdana, sans-serif;
-}
-
 body {
-  font-family: Arial, Sans-Serif, sans-serif;
-  font-size : small;
+  background-color : #FCFCFC;
+  font-family: Verdana, sans-serif;
+  font-size : 14px;
 }
 
 table.molecule {
@@ -30,7 +27,8 @@ table.molecule {
 }
 
 .molecule {
-	font: bold 12px Verdana, sans-serif;
+        font-weight: bold;
+        font-size: 12px;
 	border: 1px solid black;
 	border-top: 0px solid black;
 	border-right: 0px solid black;
@@ -291,18 +289,12 @@ div.greeting {
 
 /* Contents of original static.css end here, the rest is pi.css */
 
-body {
-  margin: 0px;
-  background-attachment : fixed;
-  background-color : #FCFCFC;
-}
 /* collapse space between headings, and where paragraph follows heading */
 hr {
   height : 1px;
 }
 
 a {
-	font-family: Verdana, sans-serif;
 	color: #3c78b5;
 	text-decoration: none;
 }
@@ -349,22 +341,17 @@ textarea {
 }
 .mainheader a {
 	color: #5C98D5;
-	font-family: Arial,Sans-Serif,sans-serif;
 }
 
 /* search and path bar (blue one) */
 .menubar {
 	padding: 5px 3px;
-	font-size: 17px;
-	line-height: 20px;
 	background-color : #3c78b5;
-
-	font-family: Verdana, arial, sans-serif;
 	color : #ffffff;
+        font-size: 12px;
 }
 
 .menubar a {
-	font-family: Verdana, arial, sans-serif;
 	color : #ffffff;
 	text-decoration : none;
 }
@@ -384,7 +371,8 @@ textarea {
 padding: 3px 0px 3px 8px;
 margin-left: 0;
 border-bottom: 1px solid #3c78b5;
-font: bold 11px Verdana, sans-serif;
+font-weight: bold;
+font-size: 12px;
 }
 
 #foldertab li {
@@ -436,31 +424,52 @@ border-color: #ffa500;
 #foldertab li a.attn:link { color: white; }
 #foldertab li a.attn:visited { color: white; }
 #foldertab li a.attn:hover {
-color: white;
-background: #ff8c00;
-border-color: #ff8c00;
+  color: white;
+  background: #ff8c00;
+  border-color: #ff8c00;
 }
 
-.rack {
-	font: bold 12px Verdana, sans-serif;
-	border: 1px solid black;
-	border-top: 0px solid black;
-	border-right: 0px solid black;
-	text-align: center;
+table.rack {
+  font-size: 12px;
+  text-align: center;
+  width: 100%;
+  max-width: 300px;
+  border-collapse: collapse;
+  table-layout: fixed;
 }
 
-.rack th {
-	border-top: 1px solid black;
-	border-right: 1px solid black;
+table.rack th {
+  font-weight: 100;
+  color: #666666;
+  text-align: right;
+}
+
+table.rack th.rack-front-label {
+  text-align: left;
+}
+
+th.rack-unit-label {
+  padding-right: 4px;
+  border-right: 1px solid #5B898A;
 }
 
 .rack td {
-	border-top: 1px solid black;
-	border-right: 1px solid black;
+  padding: 2px;
+  border-top: 1px solid #5B898A;
+  border-bottom: 1px solid #5B898A;
+  overflow: hidden;
+}
+
+table.rack td:last-child {
+  border-right: 1px solid #5B898A;
+}
+
+td.atom div {
+  height: 16px;
+  overflow: hidden;
 }
 
 .rack a {
-	font: bold 10px Verdana, sans-serif;
 	color: #000;
 	text-decoration: none;
 }
@@ -480,11 +489,13 @@ border-color: #ff8c00;
 }
 
 .rackspace h2 {
-	font: bold 25px Verdana, sans-serif;
+        font-weight: bold;
+        font-size: 25px;
 }
 
 .rackspace h3 {
-	font: bold 20px Verdana, sans-serif;
+        font-weight: bold;
+        font-size: 20px;
 }
 
 .rackspace a {
@@ -664,7 +675,6 @@ div.vlan {
 .nolink {
 	text-decoration: none;
 	color: black;
-	font-family: Arial,Sans-Serif,sans-serif;
 	font-size: small;
 }
 .nolink:hover {
@@ -734,7 +744,6 @@ div.vlan {
 /*link to popup menu (...) showed on td hover*/
 .port-popup {
 	margin-left: 3px;
-	font-family: Arial,Sans-Serif,sans-serif;
 }
 
 .l2address {
@@ -744,15 +753,19 @@ div.vlan {
 /*common rack item attributes*/
 .atom {
 	text-align: center;
-	font: bold 10px Verdana, sans-serif;
 }
+
 .state_F   { background-color: #8fbfbf; }
 .state_A   { background-color: #bfbfbf; }
 .state_U   { background-color: #bf8f8f; }
-.state_T   { background-color: #408080; }
-.state_Th  { background-color: #80ffff; }
+.state_T   { background-color: #408080; 
+  border: 1px solid #5B898A;
+}
+.state_Th  { background-color: #80ffff; font-weight: bold; 
+  border: 1px solid #5B898A;
+}
 .state_Tw  { background-color: #804040; }
-.state_Thw { background-color: #ff8080; }
+.state_Thw { background-color: #ff8080; font-weight: bold; }
 
 /* highlighting for drag selection */
 .atom.ui-selecting { 
@@ -766,7 +779,7 @@ a.img-link {
 
 /* text label with rackcode (object-rackspace tab) */
 .filter-text {
-	font-family: "Courier New",Courier,monospace;
+	font-family: monospace;
 }
 
 /* VLAN lists diff formatting (802.1Q Ports and 802.1Q Sync pages) */
@@ -806,7 +819,6 @@ ul.qlinks li {
 ul.qlinks li a {
 	font-size: 14px;
 	font-weight: bold;
-	font-family: Verdana,arial,sans-serif;
 }
 
 /* checkboxes in the MyAccount page */
@@ -867,7 +879,7 @@ a.noclick {
 }
 
 .varname {
-	font-family: "Courier New",Courier,monospace;
+	font-family: monospace;
 	font-weight: bold;
 }
 
@@ -942,7 +954,6 @@ a.noclick {
 	background-color: #3C78B5;
 	color: white;
 	text-align: center;
-	font-family: verdana, tahoma;
 	font-weight: normal;
 	padding: 0px;
 	margin: 0px -5px;

--- a/wwwroot/inc/exceptions.php
+++ b/wwwroot/inc/exceptions.php
@@ -405,6 +405,7 @@ function printPDOException ($e)
 	echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">' . "\n";
 	echo '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">' . "\n";
 	echo "<head><title>PDOException</title>\n";
+	echo "<link rel=stylesheet type='text/css' href='?module=chrome&uri=css/normalize.css' />\n";
 	echo "<link rel=stylesheet type='text/css' href='?module=chrome&uri=css/pi.css' />\n";
 	echo "<link rel=icon href='?module=chrome&uri=pix/favicon.ico' type='image/x-icon' />\n";
 	echo '</head><body>';
@@ -433,6 +434,7 @@ function printGenericException ($e)
 	echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">' . "\n";
 	echo '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">' . "\n";
 	echo "<head><title> Exception </title>\n";
+	echo "<link rel=stylesheet type='text/css' href='?module=chrome&uri=css/normalize.css' />\n";
 	echo "<link rel=stylesheet type='text/css' href='?module=chrome&uri=css/pi.css' />\n";
 	echo "<link rel=icon href='?module=chrome&uri=pix/favicon.ico' type='image/x-icon' />\n";
 	echo '</head> <body>';

--- a/wwwroot/inc/init.php
+++ b/wwwroot/inc/init.php
@@ -120,6 +120,7 @@ $pageheaders = array
 (
 	100 => "<link rel='ICON' type='image/x-icon' href='?module=chrome&uri=pix/favicon.ico' />",
 );
+addCSSInternal ('css/normalize.css');
 addCSSInternal ('css/pi.css');
 
 if (! isset ($script_mode) || $script_mode !== TRUE)

--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -964,12 +964,12 @@ function renderRack ($rack_id, $hl_obj_id = 0)
 		echo '<td>' . mkA (getImageHREF ('next', 'next rack'), 'rack', $next_id) . '</td>';
 	echo "</h2></td></tr></table>\n";
 	echo "<table class=rack border=0 cellspacing=0 cellpadding=1>\n";
-	echo "<tr><th width='10%'>&nbsp;</th><th width='20%'>Front</th>";
-	echo "<th width='50%'>Interior</th><th width='20%'>Back</th></tr>\n";
+	echo "<tr><th width='10%'>&nbsp;</th><th width='20%' class=\"rack-front-label\">Front</th>";
+	echo "<th width='50%'></th><th width='20%'>Back</th></tr>\n";
 	$reverse = considerConfiguredConstraint ($rackData, 'REVERSED_RACKS_LISTSRC');
 	for ($i = $rackData['height']; $i > 0; $i--)
 	{
-		echo '<tr><th>' . inverseRackUnit ($rackData['height'], $i, $reverse) . '</th>';
+		echo '<tr><th class="rack-unit-label">' . inverseRackUnit ($rackData['height'], $i, $reverse) . '</th>';
 		for ($locidx = 0; $locidx < 3; $locidx++)
 		{
 			if (isset ($rackData[$i][$locidx]['skipped']))


### PR DESCRIPTION
- add [normalize.css](https://necolas.github.io/normalize.css/) to align CSS defaults between browsers
- add couple of classes to simplify CSS
- tweak CSS for .rack and related classes
- remove duplication of fonts definitions

As a result, rack table is less cluttered. 
<img width="385" alt="screenshot 2019-02-10 at 14 13 58" src="https://user-images.githubusercontent.com/305871/52530309-298f7300-2d3e-11e9-9246-626415a147a5.png">
