### PR TITLE
Add snmp syncing support for Arista DCS-7050SX-64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 0.21.4
 	bugfix: amend SQL to work on MySQL 8 (Mantis#1909)
 	update: use vertical writing mode in the 802.1Q report
+	update: add snmp syncing support for Arista DCS-7050SX-64
 0.21.3 2019-06-12
 	update: add a log entry limit to the object page (Mantis#769)
 	bugfix: fix an XSS issue in an error message

--- a/wwwroot/inc/snmp.php
+++ b/wwwroot/inc/snmp.php
@@ -1662,6 +1662,15 @@ $iftable_processors['arista-any-SFP+'] = array
 	'try_next_proc' => FALSE,
 );
 
+$iftable_processors['arista-any-QSFP+'] = array
+(
+	'pattern' => '@^Ethernet([[:digit:]]+)/([[:digit:]]+)$@',
+	'replacement' => 'e\\1/\2',
+	'dict_key' => '9-1084',
+	'label' => '\\1/\2',
+	'try_next_proc' => FALSE,
+);
+
 $iftable_processors['arista-management'] = array
 (
 	'pattern' => '@^Management(1|2)$@',
@@ -4273,6 +4282,12 @@ $known_switches = array // key is system OID w/o "enterprises" prefix
 		'dict_key' => 1731,
 		'text' => 'DCS-7050S-52: 52 SFP+',
 		'processors' => array ('arista-any-SFP+', 'arista-management'),
+	),
+	'30065.1.3011.7050.3741.64' => array
+	(
+		'dict_key' => 2258,
+		'text' => 'DCS-7050SX-64: 48 SFP+ + 4 QSFP+',
+		'processors' => array ('arista-any-SFP+', 'arista-any-QSFP+', 'arista-management'),
 	),
 	'30065.1.3011.7124.3282' => array
 	(


### PR DESCRIPTION
In addition, this adds a new processor called 'arista-any-QSFP+' which should be
able to get interfaces named like the following:

Ethernet49/1
Ethernet49/2
Ethernet49/3
Ethernet49/4
Ethernet50/1
...