### PR TITLE
Enable the usage of double width or double height blades in server chassis

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -862,8 +862,18 @@ function printObjectDetailsForRenderRack ($object_id, $hl_obj_id = 0)
 			if (isset ($attrData['28'])) // slot number
 			{
 				$slot = $attrData['28']['value'];
-				if (preg_match ('/\d+/', $slot, $matches))
-					$slot = $matches[0];
+				$numRows = 1;
+				$numCols = 1;
+				if ( strpos($slot,',') !== FALSE ||
+					strpos($slot,'-') !== FALSE )
+				{
+					$pieces = explode(",", $slot);
+					$numRows = count($pieces);
+					$pieces = explode("-", $pieces[0]);
+					$slot = $pieces[0];
+					if (count($pieces) > 1)
+						$numCols = $pieces[1] - $pieces[0] + 1;
+				}
 				$slotRows[$slot] = $numRows;
 				$slotCols[$slot] = $numCols;
 				$slotInfo[$slot] = $childData['dname'];


### PR DESCRIPTION
With this patch, it is possible to define a double height blade in a server chassis,
by specifing the used slots in the object definition (e.g. Slot: 8,16 for a HP Proliant
BL 680 Blade in a c7000 chassis).

I applied the modifications to a vanilla racktables 0.21.5, and
suddenly my server blades where displaying correctly. I assume the
rest of the code for the old "slotpatch" change made it into the main
code some time ago, but this peace was missing.

Regards,

Philipp
