### PR TITLE
Allow to add text in search directly after loading the page

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -5378,7 +5378,7 @@ function showPathAndSearch ($pageno, $tabno)
 	echo "<input type=hidden name=last_page value=$pageno>";
 	echo "<input type=hidden name=last_tab value=$tabno>";
 	// This input's implicit tabindex will be the lowest unless there is a form with ports or addresses on the page.
-	echo '<label><u>S</u>earch:<input accesskey="s" type=text name=q size=20 value="';
+	echo '<label><u>S</u>earch:<input accesskey="s" type=text name=q size=20 autofocus value="';
 	echo array_key_exists ('q', $sic) ? stringForTextInputValue ($sic['q']) : '';
 	echo '"></label></form></div>';
 


### PR DESCRIPTION
At the moment, none of the text fields in RackTables has the **autofocus** tag. This commit adds this tag to the Search field, which is present  on every page.

Reason: often enough, I just want to search for a specific machine, when I open RackTables in my browser. At the moment, I have to click into the search field before I can start typing. With the new tag, the search field is automatically selected, so I can directly start pasting (or typing) my search term and only need to press the [Enter] key once done. 

As every Pro has it's Con, this results in a small difference, when RackTables presents other input fields (like in the properties section for example): normally, people have to click on a text-field, if they want to enter something. Otherwise all their content is not visible (and might get lost). With the new autofocus, the Search field will always have the focus even in this case. So people might paste their content into the search field if they blindly paste. As the old behavior (simply nothing is shown or even get saved) is worse as the new one (content ends up in the search field and just needs to be re-pasted into the correct text-field), I prefer the new behavior.


