### PR TITLE
Updated getImageHREF to allow base64 data to be used

### DIFF
--- a/wwwroot/inc/interface-lib.php
+++ b/wwwroot/inc/interface-lib.php
@@ -449,11 +449,20 @@ function printImageHREF ($tag, $title = '', $do_input = FALSE)
 function getImageHREF ($tag, $title = '', $do_input = FALSE)
 {
 	global $image;
+	if (array_key_exists ($tag, $image))
+	{
+		// Starts by 'data:' ?
+		if (stripos($image[$tag]['path'] , 'data:') === 0)
+			$src = $image[$tag]['path'];
+		else
+			$src = '?module=chrome&uri=' . $image[$tag]['path'];
+	}
+	else
+		$src = '?module=image&img=error';
+
 	$attrs = array
 	(
-		'src' => array_key_exists ($tag, $image) ?
-			'?module=chrome&uri=' . $image[$tag]['path'] :
-			'?module=image&img=error',
+		'src' => $src,
 		'border' => 0,
 	);
 	if ($title != '')

--- a/wwwroot/inc/interface-lib.php
+++ b/wwwroot/inc/interface-lib.php
@@ -449,16 +449,19 @@ function printImageHREF ($tag, $title = '', $do_input = FALSE)
 function getImageHREF ($tag, $title = '', $do_input = FALSE)
 {
 	global $image;
-	if (array_key_exists ($tag, $image))
-	{
-		// Starts by 'data:' ?
-		if (stripos($image[$tag]['path'] , 'data:') === 0)
-			$src = $image[$tag]['path'];
-		else
-			$src = '?module=chrome&uri=' . $image[$tag]['path'];
-	}
-	else
+	if (! array_key_exists ($tag, $image))
 		$src = '?module=image&img=error';
+	else
+	{
+		$srctype = array_key_exists ('srctype', $image[$tag]) ? $image[$tag]['srctype'] : 'path';
+
+		if ($srctype == 'path' && array_key_exists ('path', $image[$tag]))
+			$src = '?module=chrome&uri=' . $image[$tag]['path'];
+		elseif ($srctype == 'dataurl' && array_key_exists ('data', $image[$tag]))
+			$src = 'data:' . $image[$tag]['data'];
+		else
+			throw new RackTablesError ('$image is not properly set', RackTablesError::INTERNAL);
+	}
 
 	$attrs = array
 	(


### PR DESCRIPTION
This patch add the ability to embed images in base64.

### Why I believe this could be useful
As I'm finishing the implementation of a plugin with the new plugin architecture, I'm trying to achieve a setup avoiding to copy files in `wwwroot` subfolders `css`, `js` and `pix`. The goal is to keep plugin setup as simple as possible, and avoiding the need to copy files that will probably stay forever after plugin uninstall.

For CSS and JS ressources, I had no problem thanks to `addJSInternal()` and `addCSSInternal()` methods, but for the main page icon `$image['pluginname']['path']`, I didn't found any other workaround than embedding icon in base64.

Best regards,
Breloc
