### PR TITLE
fix warnings for optional parameters under PHP 8.0

### DIFF
--- a/wwwroot/inc/database.php
+++ b/wwwroot/inc/database.php
@@ -4853,7 +4853,7 @@ function commitAddFile ($name, $type, $contents, $comment)
 	}
 }
 
-function commitReplaceFile ($file_id = 0, $contents)
+function commitReplaceFile ($file_id, $contents)
 {
 	global $dbxlink;
 	$query = $dbxlink->prepare('UPDATE File SET mtime = NOW(), contents = ?, size = LENGTH(contents), thumbnail = NULL WHERE id = ?');
@@ -5565,7 +5565,7 @@ function makeVlanListWhere ($db_field_name, $vlan_list)
 	return $ret;
 }
 
-function upd8021QPort ($instance = 'desired', $object_id, $port_name, $port, $before)
+function upd8021QPort ($instance, $object_id, $port_name, $port, $before)
 {
 	global $tablemap_8021q;
 	if (!array_key_exists ($instance, $tablemap_8021q))
@@ -5638,7 +5638,7 @@ function upd8021QPort ($instance = 'desired', $object_id, $port_name, $port, $be
 	return $changed ? 1 : 0;
 }
 
-function replace8021QPorts ($instance = 'desired', $object_id, $before, $changes)
+function replace8021QPorts ($instance, $object_id, $before, $changes)
 {
 	$done = 0;
 	foreach ($changes as $pn => $port)


### PR DESCRIPTION
Running racktables under PHP 8.0 seems fine.

I collected some warnings:

```
# sort -u /logs/php-error.log
PHP Deprecated:  Required parameter $before follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5568
PHP Deprecated:  Required parameter $before follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5641
PHP Deprecated:  Required parameter $changes follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5641
PHP Deprecated:  Required parameter $contents follows optional parameter $file_id in /usr/local/www/racktables/wwwroot/inc/database.php on line 4856
PHP Deprecated:  Required parameter $object_id follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5568
PHP Deprecated:  Required parameter $object_id follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5641
PHP Deprecated:  Required parameter $port follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5568
PHP Deprecated:  Required parameter $port_name follows optional parameter $instance in /usr/local/www/racktables/wwwroot/inc/database.php on line 5568

```
The optional for seems not in use, Plugins not tested.

grep -r of the function names finds only complete function calls.

The included patch fixes the issue for me.
