### PR TITLE
Removed fancy showLogoutURL()

### DIFF
--- a/wwwroot/inc/interface.php
+++ b/wwwroot/inc/interface.php
@@ -71,13 +71,6 @@ $attrtypes = array
 	'date' => '[T] date'
 );
 
-function showLogoutURL ()
-{
-	$https = (isset ($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 's' : '';
-	$port = (! in_array ($_SERVER['SERVER_PORT'], array (80, 443))) ? ':' . $_SERVER['SERVER_PORT'] : '';
-	printf ('http%s://logout@%s%s%s?logout', $https, $_SERVER['SERVER_NAME'], $port, $_SERVER['PHP_SELF']);
-}
-
 $quick_links = NULL; // you can override this in your local.php, but first initialize it with getConfiguredQuickLinks()
 
 function renderQuickLinks()
@@ -104,9 +97,7 @@ function renderInterfaceHTML ($pageno, $tabno, $payload)
 	echo '<div class=mainheader>';
 	echo '<div style="float: right" class=greeting>';
 	echo mkA ($remote_displayname, 'myaccount', NULL, 'default');
-	echo ' [ <a href="';
-	showLogoutURL();
-	echo '">logout</a> ]</div>'; // greeting
+	echo ' [ <a href="./?logout">logout</a> ]</div>';
 	echo getConfigVar ('enterprise') . ' RackTables ';
 	echo '<a href="https://racktables.org/" title="Visit RackTables site">' . CODE_VERSION . '</a>';
 	renderQuickLinks();


### PR DESCRIPTION
When running Racktables in a docker container, behind a nginx reversed proxy. The logout URL doesn't work. This is because there is no "server_name" available. This fixes that issue. Also, there's no need to generate such a "fancy" logout URL.