### PR TITLE
Update auth.php to use simplesamlphp namespaces

### DIFF
--- a/wwwroot/inc/auth.php
+++ b/wwwroot/inc/auth.php
@@ -273,7 +273,7 @@ function authenticated_via_saml (&$saml_username = NULL, &$saml_displayname = NU
 	if (! file_exists ($SAML_options['simplesamlphp_basedir'] . '/lib/_autoload.php'))
 		throw new RackTablesError ('Configured for SAML authentication, but simplesaml is not found.', RackTablesError::MISCONFIGURED);
 	require_once ($SAML_options['simplesamlphp_basedir'] . '/lib/_autoload.php');
-	$as = new SimpleSAML_Auth_Simple ($SAML_options['sp_profile']);
+	$as = new SimpleSAML\Auth\Simple ($SAML_options['sp_profile']);
 	if (! $as->isAuthenticated())
 		$as->requireAuth();
 	$attributes = $as->getAttributes();
@@ -291,7 +291,7 @@ function saml_logout ()
 	if (! file_exists ($SAML_options['simplesamlphp_basedir'] . '/lib/_autoload.php'))
 		throw new RackTablesError ('Configured for SAML authentication, but simplesaml is not found.', RackTablesError::MISCONFIGURED);
 	require_once ($SAML_options['simplesamlphp_basedir'] . '/lib/_autoload.php');
-	$as = new SimpleSAML_Auth_Simple ($SAML_options['sp_profile']);
+	$as = new SimpleSAML\Auth\Simple ($SAML_options['sp_profile']);
 	header("Location: ".$as->getLogoutURL('/'));
 	exit;
 }


### PR DESCRIPTION
Fix for the error logged by Racktables: 

"The class or interface 'SimpleSAML_Auth_Simple' is now using namespaces, please use 'SimpleSAML\Auth\Simple'"

SimpleSAMLPHP is now using namespaces, and this changes the class reference in code to use the new name.

Tested on my running Racktables 0.22.0 instance with SimpleSAMLphp v1.19.1 and PHP 7.2.24. The log errors are gone.