### PR TITLE
Unescape varvalue before set

### DIFF
--- a/wwwroot/inc/ophandlers.php
+++ b/wwwroot/inc/ophandlers.php
@@ -1498,7 +1498,7 @@ function updateUI ()
 		{
 			assertStringArg ("${i}_varvalue", TRUE);
 			$varname = genericAssertion ("${i}_varname", 'string');
-			$varvalue = $_REQUEST["${i}_varvalue"];
+			$varvalue = htmlspecialchars_decode($_REQUEST["${i}_varvalue"], ENT_QUOTES);
 			// If form value = value in DB, don't bother updating DB.
 			if (isConfigVarChanged ($varname, $varvalue))
 				setConfigVar ($varname, $varvalue);


### PR DESCRIPTION
There is a bug involving values that have been modified using the htmlspecialchars function. This bug results in adding "amp;" to the "&" character. Consequently, after multiple commits, the value will appear as something like this: "&amp;amp;amp;...".