### PR TITLE
Fixes #2105 - database tables can't be created on MySQL >= 8.4 because KEY is not unique

### DIFF
--- a/wwwroot/inc/install.php
+++ b/wwwroot/inc/install.php
@@ -643,13 +643,13 @@ function get_pseudo_file ($name)
 ) ENGINE=InnoDB";
 
 		$query[] = "CREATE TABLE `IPv4LB` (
-  `object_id` int(10) unsigned default NULL,
+  `object_id` int(10) unsigned NOT NULL,
   `rspool_id` int(10) unsigned default NULL,
-  `vs_id` int(10) unsigned default NULL,
+  `vs_id` int(10) unsigned NOT NULL,
   `prio` varchar(255) default NULL,
   `vsconfig` text,
   `rsconfig` text,
-  UNIQUE KEY `LB-VS` (`object_id`,`vs_id`),
+  PRIMARY KEY (`object_id`,`vs_id`),
   KEY `IPv4LB-FK-rspool_id` (`rspool_id`),
   KEY `IPv4LB-FK-vs_id` (`vs_id`),
   CONSTRAINT `IPv4LB-FK-vs_id` FOREIGN KEY (`vs_id`) REFERENCES `IPv4VS` (`id`),

--- a/wwwroot/inc/install.php
+++ b/wwwroot/inc/install.php
@@ -994,7 +994,7 @@ function get_pseudo_file ($name)
   `comment` text,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `asset_no` (`asset_no`),
-  KEY `id-tid` (`id`,`objtype_id`),
+  UNIQUE KEY `id-tid` (`id`,`objtype_id`),
   KEY `type_id` (`objtype_id`,`id`)
 ) ENGINE=InnoDB";
 
@@ -1063,7 +1063,7 @@ function get_pseudo_file ($name)
   PRIMARY KEY  (`id`),
   UNIQUE KEY `tag` (`tag`),
   KEY `TagTree-K-parent_id` (`parent_id`),
-  KEY `id-is_assignable` (`id`,`is_assignable`),
+  UNIQUE KEY `id-is_assignable` (`id`,`is_assignable`),
   CONSTRAINT `TagTree-K-parent_id` FOREIGN KEY (`parent_id`) REFERENCES `TagTree` (`id`)
 ) ENGINE=InnoDB";
 


### PR DESCRIPTION
Quote:
```
When using MySQL 8.4 or higher, there are a few tables that can't be created because a Key is not unique and there is a foreign key that references it, and from MySQL 8.4 it's not allowed to reference non-unique KEYs.

the keys that are bad (not UNIQUE) are:
Object.id-tid
TagTree.id-is_assignable

The fix:
ALTER TABLE Object DROP KEY `id-tid`, ADD UNIQUE KEY `id-tid` (`id`,`objtype_id`);
ALTER TABLE TagTree DROP KEY `id-is_assignable`, ADD UNIQUE KEY `id-is_assignable` (`id`,`is_assignable`);
```

Additional info: https://bugs.mysql.com/bug.php?id=114838